### PR TITLE
test all allocated symbols are properly accounted

### DIFF
--- a/pkg/parser/alloctable/global/global.go
+++ b/pkg/parser/alloctable/global/global.go
@@ -1,0 +1,60 @@
+package global
+
+import (
+	"fmt"
+
+	"github.com/gofed/symbols-extractor/pkg/parser/alloctable"
+)
+
+// Table captures list of allocated symbols for each package and its files
+type Table struct {
+	tables map[string]map[string]*alloctable.Table
+}
+
+func New() *Table {
+	return &Table{
+		tables: make(map[string]map[string]*alloctable.Table, 0),
+	}
+}
+
+func (t *Table) Add(packagePath, file string, table *alloctable.Table) {
+	if _, ok := t.tables[packagePath]; !ok {
+		t.tables[packagePath] = make(map[string]*alloctable.Table, 0)
+	}
+
+	if _, ok := t.tables[packagePath][file]; !ok {
+		t.tables[packagePath][file] = table
+	}
+}
+
+func (t *Table) Packages() []string {
+	var packages []string
+	for key, _ := range t.tables {
+		packages = append(packages, key)
+	}
+	return packages
+}
+
+func (t *Table) Files(packagePath string) []string {
+	var files []string
+	fileTable, ok := t.tables[packagePath]
+	if !ok {
+		return nil
+	}
+	for key, _ := range fileTable {
+		files = append(files, key)
+	}
+	return files
+}
+
+func (t *Table) Lookup(packagePath, file string) (*alloctable.Table, error) {
+	files, ok := t.tables[packagePath]
+	if !ok {
+		return nil, fmt.Errorf("Unable to find package-level allocated symbol table for package %q", packagePath)
+	}
+	table, exists := files[file]
+	if !exists {
+		return nil, fmt.Errorf("Unable to find file-level allocated symbol table for package %q and file %q", packagePath, file)
+	}
+	return table, nil
+}

--- a/pkg/parser/expression/expression_parser.go
+++ b/pkg/parser/expression/expression_parser.go
@@ -582,14 +582,14 @@ func (ep *Parser) parseSelectorExpr(expr *ast.SelectorExpr) (gotypes.DataType, e
 			return ep.retrieveStructField(structDefsymbol, expr.Sel.Name)
 		case *gotypes.Selector:
 			// qid to different package
-			fmt.Printf("Item: %#v\n", def.Item)
-			fmt.Printf("Prefix: %#v\n", def.Prefix)
 			pq, ok := def.Prefix.(*gotypes.Packagequalifier)
 			if !ok {
 				return nil, fmt.Errorf("Trying to retrieve a %v field from a pointer to non-qualified struct data type: %#v", expr.Sel.Name, def)
 			}
 			structDefsymbol, _, err := ep.Config.Lookup(&gotypes.Identifier{Def: def.Item, Package: pq.Path})
-			fmt.Printf("FF: %#v, %v\n", structDefsymbol, err)
+			if err != nil {
+				return nil, err
+			}
 			return ep.retrieveStructField(structDefsymbol, expr.Sel.Name)
 		default:
 			return nil, fmt.Errorf("Trying to retrieve a %v field from a pointer to non-struct data type: %#v", expr.Sel.Name, xType.Def)

--- a/pkg/parser/parser_test.go
+++ b/pkg/parser/parser_test.go
@@ -5,6 +5,7 @@ import (
 	"reflect"
 	"testing"
 
+	"github.com/gofed/symbols-extractor/pkg/parser/alloctable"
 	"github.com/gofed/symbols-extractor/pkg/parser/symboltable"
 	"github.com/gofed/symbols-extractor/pkg/types"
 )
@@ -16,6 +17,7 @@ func TestProjectParser(t *testing.T) {
 		t.Errorf("Parse error: %v", err)
 	}
 	gtable := pp.GlobalSymbolTable()
+	atable := pp.GlobalAllocTable()
 
 	// Check all packages and its symbols are available
 	pkgs := make(map[string]struct{}, 0)
@@ -110,6 +112,44 @@ func TestProjectParser(t *testing.T) {
 			y, _ := json.Marshal(st)
 			t.Errorf("Symbol table %q mismatch. Got:\n%v\nExpected:\n%v", expectedPackages["unordered"], string(x), string(y))
 		}
+
+		at := alloctable.New()
+		// type Struct struct {
+		// 	i MyInt
+		// 	impa *pkg.Imp
+		// 	impb *pkgb.Imp
+		// }
+		at.AddSymbol(expectedPackages["unordered"], "MyInt")
+		at.AddSymbol(expectedPackages["pkg"], "Imp")
+		at.AddSymbol(expectedPackages["pkgb"], "Imp")
+		// type MyInt int
+		at.AddSymbol("", "int")
+		// func Nic() *pkg.Imp {
+		// 	pkg.Nic().Imp.Size
+		// 	return &pkg.Imp{
+		// 		Name: "haluz",
+		// 		Size: 2,
+		// 	}
+		// }
+		at.AddSymbol(expectedPackages["pkg"], "Imp")
+		at.AddSymbol(expectedPackages["pkg"], "Nic")
+		// accounted as it is returned by pkg.Nic() and its field Imp is accessed
+		at.AddSymbol(expectedPackages["pkg"], "Imp")
+		// Accessing field Imp of type Imp does not imply allocation of the type Imp itself,
+		// Return type of the Nic() can change but it the field Imp is still available,
+		// The change is backward compatible. Thus, the type Imp must not be allocated.
+		at.AddDataTypeField(expectedPackages["pkg"], "Imp", "Imp")
+		at.AddDataTypeField(expectedPackages["pkgb"], "Imp", "Size")
+		at.AddSymbol(expectedPackages["pkg"], "Imp")
+		at.AddDataTypeField(expectedPackages["pkg"], "Imp", "Name")
+		at.AddDataTypeField(expectedPackages["pkg"], "Imp", "Size")
+
+		pat, _ := atable.Lookup(expectedPackages["unordered"], "unordered.go")
+		if !reflect.DeepEqual(at, pat) {
+			x, _ := json.Marshal(pat)
+			y, _ := json.Marshal(at)
+			t.Errorf("Alloc symbol table %q mismatch.\nGot:\n%v\nExpected:\n%v", expectedPackages["pkg"], string(x), string(y))
+		}
 	}
 
 	// Check unordered/pkg ST
@@ -168,6 +208,19 @@ func TestProjectParser(t *testing.T) {
 			y, _ := json.Marshal(st)
 			t.Errorf("Symbol table %q mismatch. Got:\n%v\nExpected:\n%v", expectedPackages["pkg"], string(x), string(y))
 		}
+		at := alloctable.New()
+		at.AddSymbol("", "string")
+		at.AddSymbol("", "int")
+		at.AddSymbol("github.com/gofed/symbols-extractor/pkg/parser/testdata/unordered/pkgb", "Imp")
+		at.AddSymbol("github.com/gofed/symbols-extractor/pkg/parser/testdata/unordered/pkg", "Imp")
+		at.AddSymbol("github.com/gofed/symbols-extractor/pkg/parser/testdata/unordered/pkg", "Imp")
+
+		pat, _ := atable.Lookup(expectedPackages["pkg"], "pkg.go")
+		if !reflect.DeepEqual(at, pat) {
+			x, _ := json.Marshal(pat)
+			y, _ := json.Marshal(at)
+			t.Errorf("Alloc symbol table %q mismatch.\nGot:\n%v\nExpected:\n%v", expectedPackages["pkg"], string(x), string(y))
+		}
 	}
 
 	// Check unordered/pkgb ST
@@ -197,7 +250,17 @@ func TestProjectParser(t *testing.T) {
 		if !reflect.DeepEqual(st, pst) {
 			x, _ := json.Marshal(pst)
 			y, _ := json.Marshal(st)
-			t.Errorf("Symbol table %q mismatch. Got:\n%v\nExpected:\n%v", expectedPackages["pkgb"], string(x), string(y))
+			t.Errorf("Symbol table %q mismatch.\nGot:\n%v\nExpected:\n%v", expectedPackages["pkgb"], string(x), string(y))
+		}
+		at := alloctable.New()
+		at.AddSymbol("", "string")
+		at.AddSymbol("", "int")
+
+		pat, _ := atable.Lookup(expectedPackages["pkgb"], "pkg.go")
+		if !reflect.DeepEqual(at, pat) {
+			x, _ := json.Marshal(pat)
+			y, _ := json.Marshal(at)
+			t.Errorf("Alloc symbol table %q mismatch.\nGot:\n%v\nExpected:\n%v", expectedPackages["pkgb"], string(x), string(y))
 		}
 	}
 }

--- a/pkg/parser/statement/statement_parser.go
+++ b/pkg/parser/statement/statement_parser.go
@@ -875,6 +875,8 @@ func (sp *Parser) Parse(statement ast.Stmt) error {
 }
 
 func (sp *Parser) parseFuncHeadVariables(funcDecl *ast.FuncDecl) error {
+	sp.AllocatedSymbolsTable.Lock()
+	defer sp.AllocatedSymbolsTable.Unlock()
 	if funcDecl.Recv != nil {
 		// Receiver has a single parametr
 		// https://golang.org/ref/spec#Receiver


### PR DESCRIPTION
Number of occurrences of each allocated symbol should correspond to the real number of occurrences. This is a preparation for file position detection of allocated symbols.