### PR TITLE
Towards processing runtime package

### DIFF
--- a/pkg/parser/expression/expression_parser.go
+++ b/pkg/parser/expression/expression_parser.go
@@ -727,7 +727,7 @@ func (ep *Parser) parseSelectorExpr(expr *ast.SelectorExpr) (gotypes.DataType, e
 			// Get struct's definition given by its identifier
 			structDefsymbol, _, err := ep.Config.Lookup(def)
 			if err != nil {
-				return nil, fmt.Errorf("Cannot retrieve %v from the symbol table", def.Def)
+				return nil, fmt.Errorf("Cannot retrieve identifier %q from the symbol table: %v", def.Def, err)
 			}
 			return ep.retrieveStructField(structDefsymbol, expr.Sel.Name)
 		case *gotypes.Selector:

--- a/pkg/parser/expression/parser_test.go
+++ b/pkg/parser/expression/parser_test.go
@@ -46,7 +46,8 @@ func TestBinaryExpr(t *testing.T) {
 		expectedError bool
 	}{
 		{&gotypes.Builtin{}, "var FooB1 int     = 1 + 4", false},
-		{&gotypes.Builtin{}, "var FooB2 float32 = 1.2 + 4", true},
+		// 1.2 + 4 is an untyped constant so combination of int and float is permitted
+		{&gotypes.Builtin{}, "var FooB2 float32 = 1.2 + 4", false},
 		{&gotypes.Identifier{Def: userType}, "var FooU3 FInt    = FInt(12) + FInt(4)", false},
 		{&gotypes.Identifier{Def: userType}, "var FooU4 FInt    = FooU3 * FooU3", false},
 		{&gotypes.Builtin{}, "var FooB5 uint32  = uint32(FooU3) + uint32(FooU4)", false},

--- a/pkg/parser/file/file_parser.go
+++ b/pkg/parser/file/file_parser.go
@@ -6,7 +6,6 @@ import (
 	"path"
 	"strings"
 
-	"github.com/gofed/symbols-extractor/pkg/parser/symboltable"
 	"github.com/gofed/symbols-extractor/pkg/parser/types"
 	gotypes "github.com/gofed/symbols-extractor/pkg/types"
 	"github.com/golang/glog"
@@ -14,10 +13,11 @@ import (
 
 // Payload stores symbols for parsing/processing
 type Payload struct {
-	DataTypes []*ast.TypeSpec
-	Variables []*ast.ValueSpec
-	Functions []*ast.FuncDecl
-	Imports   []*ast.ImportSpec
+	DataTypes         []*ast.TypeSpec
+	Variables         []*ast.ValueSpec
+	Functions         []*ast.FuncDecl
+	FunctionDeclsOnly bool
+	Imports           []*ast.ImportSpec
 }
 
 type FileParser struct {
@@ -111,6 +111,7 @@ func (fp *FileParser) parseTypeSpecs(specs []*ast.TypeSpec) ([]*ast.TypeSpec, er
 		// Which can result in re-allocation. It should be enough two-level allocated symbol table.
 		typeDef, err := fp.TypeParser.Parse(spec.Type)
 		if err != nil {
+			glog.Warningf("File parse TypeParser error: %v\n", err)
 			postponed = append(postponed, spec)
 			continue
 		}
@@ -132,6 +133,7 @@ func (fp *FileParser) parseValueSpecs(specs []*ast.ValueSpec) ([]*ast.ValueSpec,
 
 		defs, err := fp.StmtParser.ParseValueSpec(spec)
 		if err != nil {
+			glog.Warningf("File parse ValueSpec %q error: %v\n", spec.Names[0].Name, err)
 			postponed = append(postponed, spec)
 			continue
 		}
@@ -147,35 +149,77 @@ func (fp *FileParser) parseValueSpecs(specs []*ast.ValueSpec) ([]*ast.ValueSpec,
 	return postponed, nil
 }
 
+func (fp *FileParser) parseFuncDeclaration(spec *ast.FuncDecl) (bool, error) {
+	glog.Infof("Parsing function %q declaration", spec.Name.Name)
+	// process function definitions as the last
+	funcDef, err := fp.StmtParser.ParseFuncDecl(spec)
+	if err != nil {
+		// if the function declaration is not fully processed (e.g. missing data type)
+		// skip it and postponed its processing
+		glog.Infof("Postponing function %q declaration parseFuncDecls processing due to: %v", spec.Name.Name, err)
+		return true, nil
+	}
+
+	if method, ok := funcDef.(*gotypes.Method); ok {
+		var receiverDataType string
+		switch rExpr := method.Receiver.(type) {
+		case *gotypes.Identifier:
+			receiverDataType = rExpr.Def
+		case *gotypes.Pointer:
+			if ident, ok := rExpr.Def.(*gotypes.Identifier); ok {
+				receiverDataType = ident.Def
+			} else {
+				return false, fmt.Errorf("Expecting a pointer to an identifier as a receiver for %q method, got %#v instead", spec.Name.Name, rExpr)
+			}
+		default:
+			return false, fmt.Errorf("Expecting an identifier or a pointer to an identifier as a receiver for %q method, got %#v instead", spec.Name.Name, method.Receiver)
+		}
+
+		def, err := fp.SymbolTable.LookupMethod(receiverDataType, spec.Name.Name)
+		glog.Infof("Looking I up for %q.%q\terr: %v\tDef: %#v\tRecv: %#v\n", receiverDataType, spec.Name.Name, err, def, spec.Recv.List)
+		// method declaration already exist
+		if err == nil {
+			return false, nil
+		}
+	} else {
+		def, err := fp.SymbolTable.LookupFunction(spec.Name.Name)
+		glog.Infof("Looking II up for %q\terr: %v\tDef: %#v\tRecv: %#v\n", spec.Name.Name, err, def, spec.Recv)
+		// function declaration already exist
+		if err == nil {
+			return false, nil
+		}
+	}
+
+	if err := fp.SymbolTable.AddFunction(&gotypes.SymbolDef{
+		Name:    spec.Name.Name,
+		Package: fp.PackageName,
+		Def:     funcDef,
+	}); err != nil {
+		glog.Info("Error during parsing of function %q declaration: %v", spec.Name.Name, err)
+		return false, err
+	}
+	return false, nil
+}
+
+func (fp *FileParser) parseFuncDecls(specs []*ast.FuncDecl) error {
+	for _, spec := range specs {
+		if _, err := fp.parseFuncDeclaration(spec); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
 func (fp *FileParser) parseFuncs(specs []*ast.FuncDecl) ([]*ast.FuncDecl, error) {
 	var postponed []*ast.FuncDecl
 	for _, spec := range specs {
-
-		_, sType, err := fp.SymbolTable.Lookup(spec.Name.Name)
-		// In case the function declaration has been parsed previously
-		if err != nil || sType != symboltable.FunctionSymbol {
-			// process function definitions as the last
-			funcDef, err := fp.StmtParser.ParseFuncDecl(spec)
-			if err != nil {
-				// TODO(jchaloup): this should not error (ever)
-				// It can happen an identifier is unknown. Given all imported packages
-				// are already processed, the identifier comes from the same package, just
-				// from a different file. So the type parser should assume that and choose
-				// symbol's origin accordingaly.
-				glog.Warningf("File parse error: %v\n", err)
-				postponed = append(postponed, spec)
-				continue
-			}
-
-			if err := fp.SymbolTable.AddFunction(&gotypes.SymbolDef{
-				Name:    spec.Name.Name,
-				Package: fp.PackageName,
-				Def:     funcDef,
-			}); err != nil {
-				return nil, err
-			}
-		} else {
-			glog.Infof("Re-processing function %q\n", spec.Name.Name)
+		postpone, err := fp.parseFuncDeclaration(spec)
+		if err != nil {
+			return nil, err
+		}
+		if postpone {
+			postponed = append(postponed, spec)
 		}
 
 		// if an error is returned, put the function's AST into a context list
@@ -183,7 +227,7 @@ func (fp *FileParser) parseFuncs(specs []*ast.FuncDecl) ([]*ast.FuncDecl, error)
 		// TODO(jchaloup): reset the alloc table back to the state before the body got processed
 		// in case the processing ended with an error
 		if err := fp.StmtParser.ParseFuncBody(spec); err != nil {
-			glog.Warningf("File parse error: %v\n", err)
+			glog.Warningf("File parse %q Funcs error: %v\n", spec.Name.Name, err)
 			postponed = append(postponed, spec)
 			continue
 		}
@@ -213,31 +257,64 @@ func (fp *FileParser) Parse(p *Payload) error {
 		}
 	}
 
+	printFuncNames := func(funcs []*ast.FuncDecl) []string {
+		var names []string
+		for _, f := range funcs {
+			names = append(names, f.Name.Name)
+		}
+		return names
+	}
+
+	printVarNames := func(vars []*ast.ValueSpec) []string {
+		var names []string
+		for _, f := range vars {
+			for _, n := range f.Names {
+				names = append(names, n.Name)
+			}
+		}
+		return names
+	}
+
 	// Data definitions as second
 	{
+		glog.Infof("\n\nBefore parseTypeSpecs: %v", len(p.DataTypes))
 		postponed, err := fp.parseTypeSpecs(p.DataTypes)
 		if err != nil {
 			return err
 		}
 		p.DataTypes = postponed
+		glog.Infof("\n\nAfter parseTypeSpecs: %v", len(p.DataTypes))
+	}
+
+	// Function/Method declarations
+	{
+		glog.Infof("\n\nBefore parseFuncDecls: %v\tNames: %v\n", len(p.Functions), strings.Join(printFuncNames(p.Functions), ","))
+		if err := fp.parseFuncDecls(p.Functions); err != nil {
+			return err
+		}
+		glog.Infof("\n\nAfter parseFuncDecls: %v\tNames: %v\n", len(p.Functions), strings.Join(printFuncNames(p.Functions), ","))
 	}
 
 	// // Vars/constants
 	{
+		glog.Infof("\n\nBefore parseValueSpecs: %v\tNames: %v\n", len(p.Variables), strings.Join(printVarNames(p.Variables), ","))
 		postponed, err := fp.parseValueSpecs(p.Variables)
 		if err != nil {
 			return err
 		}
 		p.Variables = postponed
+		glog.Infof("\n\nAfter parseValueSpecs: %v\tNames: %v\n", len(p.Variables), strings.Join(printVarNames(p.Variables), ","))
 	}
 
 	// // Funcs
-	{
+	if !p.FunctionDeclsOnly {
+		glog.Infof("\n\nBefore parseFuncs: %v\tNames: %v\n", len(p.Functions), strings.Join(printFuncNames(p.Functions), ","))
 		postponed, err := fp.parseFuncs(p.Functions)
 		if err != nil {
 			return err
 		}
 		p.Functions = postponed
+		glog.Infof("\n\nAfter parseFuncs: %v\tNames: %v\n", len(p.Functions), strings.Join(printFuncNames(p.Functions), ","))
 	}
 
 	fmt.Printf("AllocST for %q\n", fp.PackageName)

--- a/pkg/parser/parser_test.go
+++ b/pkg/parser/parser_test.go
@@ -134,6 +134,8 @@ func TestProjectParser(t *testing.T) {
 		at.AddSymbol(expectedPackages["pkg"], "Nic")
 		// accounted as it is returned by pkg.Nic() and its field Imp is accessed
 		at.AddSymbol(expectedPackages["pkg"], "Imp")
+		// temporary bump by one once the allocated symbol is extended with file.go:linenumber
+		at.AddSymbol(expectedPackages["pkg"], "Imp")
 		// Accessing field Imp of type Imp does not imply allocation of the type Imp itself,
 		// Return type of the Nic() can change but it the field Imp is still available,
 		// The change is backward compatible. Thus, the type Imp must not be allocated.
@@ -212,6 +214,8 @@ func TestProjectParser(t *testing.T) {
 		at.AddSymbol("builtin", "int")
 		at.AddSymbol("github.com/gofed/symbols-extractor/pkg/parser/testdata/unordered/pkgb", "Imp")
 		at.AddSymbol("github.com/gofed/symbols-extractor/pkg/parser/testdata/unordered/pkg", "Imp")
+		at.AddSymbol("github.com/gofed/symbols-extractor/pkg/parser/testdata/unordered/pkg", "Imp")
+		// temporary bump by one once the allocated symbol is extended with file.go:linenumber
 		at.AddSymbol("github.com/gofed/symbols-extractor/pkg/parser/testdata/unordered/pkg", "Imp")
 
 		pat, _ := atable.Lookup(expectedPackages["pkg"], "pkg.go")

--- a/pkg/parser/statement/statement_parser.go
+++ b/pkg/parser/statement/statement_parser.go
@@ -41,7 +41,8 @@ func (ep *Parser) parseReceiver(receiver ast.Expr, skip_allocated bool) (gotypes
 		}
 
 		return &gotypes.Identifier{
-			Def: typedExpr.Name,
+			Def:     typedExpr.Name,
+			Package: ep.PackageName,
 		}, nil
 	case *ast.StarExpr:
 		switch idExpr := typedExpr.X.(type) {
@@ -61,7 +62,8 @@ func (ep *Parser) parseReceiver(receiver ast.Expr, skip_allocated bool) (gotypes
 
 			return &gotypes.Pointer{
 				Def: &gotypes.Identifier{
-					Def: idExpr.Name,
+					Def:     idExpr.Name,
+					Package: ep.PackageName,
 				},
 			}, nil
 		default:

--- a/pkg/parser/statement/statement_parser.go
+++ b/pkg/parser/statement/statement_parser.go
@@ -13,6 +13,7 @@ import (
 // Parser parses go statements, e.g. block, declaration and definition of a function/method
 type Parser struct {
 	*types.Config
+	lastConstType gotypes.DataType
 }
 
 // New creates an instance of a statement parser
@@ -107,8 +108,6 @@ func (sp *Parser) ParseFuncDecl(d *ast.FuncDecl) (gotypes.DataType, error) {
 		return nil, fmt.Errorf("Receiver is not a single parameter: %#v, %#v", d.Recv, d.Recv.List[0].Names)
 	}
 
-	//fmt.Printf("Rec Name: %#v\n", (*d.Recv).List[0].Names[0].Name)
-
 	recDef, err := sp.parseReceiver(d.Recv.List[0].Type, false)
 	if err != nil {
 		return nil, err
@@ -123,7 +122,11 @@ func (sp *Parser) ParseFuncDecl(d *ast.FuncDecl) (gotypes.DataType, error) {
 }
 
 func (sp *Parser) ParseFuncBody(funcDecl *ast.FuncDecl) error {
-	glog.Infof("Processing function body: %#v\n", funcDecl)
+	if funcDecl.Name == nil {
+		glog.Infof("Processing function body of %#v\n", funcDecl)
+	} else {
+		glog.Infof("Processing function body of %q: %#v\n", funcDecl.Name.Name, funcDecl)
+	}
 	// Function/method signature is already stored in a symbol table.
 	// From function/method's AST get its receiver, parameters and results,
 	// construct a first level of a multi-level symbol table stack..
@@ -154,7 +157,7 @@ func (sp *Parser) ParseFuncBody(funcDecl *ast.FuncDecl) error {
 }
 
 func (sp *Parser) ParseValueSpec(spec *ast.ValueSpec) ([]*gotypes.SymbolDef, error) {
-	glog.Infof("Processing value spec: %#v\n", spec)
+	glog.Infof("Processing value spec: %#v\n\tNames: %#v\n", spec, spec.Names[0])
 
 	nLen := len(spec.Names)
 	vLen := len(spec.Values)
@@ -175,6 +178,7 @@ func (sp *Parser) ParseValueSpec(spec *ast.ValueSpec) ([]*gotypes.SymbolDef, err
 	var symbolsDef = make([]*gotypes.SymbolDef, 0)
 
 	for i := 0; i < vLen; i++ {
+		glog.Infof("----Processing ast.ValueSpec[%v]: %#v\n", i, spec.Values[i])
 		if typeDef == nil && spec.Values[i] == nil {
 			return nil, fmt.Errorf("No type nor value in ValueSpec declaration")
 		}
@@ -184,6 +188,7 @@ func (sp *Parser) ParseValueSpec(spec *ast.ValueSpec) ([]*gotypes.SymbolDef, err
 		if err != nil {
 			return nil, err
 		}
+
 		if len(valueExpr) != 1 {
 			return nil, fmt.Errorf("Expecting a single expression. Got a list instead: %#v", valueExpr)
 		}
@@ -191,13 +196,29 @@ func (sp *Parser) ParseValueSpec(spec *ast.ValueSpec) ([]*gotypes.SymbolDef, err
 		if spec.Names[i].Name == "_" {
 			continue
 		}
+		glog.Infof("valueExpr: %#v\ttypeDef: %#v\n", valueExpr, typeDef)
 		if typeDef != nil {
 			symbolsDef = append(symbolsDef, &gotypes.SymbolDef{
 				Name:    spec.Names[i].Name,
 				Package: sp.PackageName,
 				Def:     typeDef,
 			})
+			if builtin, ok := valueExpr[0].(*gotypes.Builtin); ok {
+				if builtin.Def == "iota" {
+					// https://splice.com/blog/iota-elegant-constants-golang/
+					sp.lastConstType = typeDef
+				}
+			}
 		} else {
+			// If the iota is used, the data type must be known
+			if builtin, ok := valueExpr[0].(*gotypes.Builtin); ok {
+				// if an untyped const is iota, it defaults to int
+				if builtin.Def == "iota" {
+					builtin.Def = "int"
+					builtin.Untyped = true
+				}
+				sp.lastConstType = builtin
+			}
 			symbolsDef = append(symbolsDef, &gotypes.SymbolDef{
 				Name:    spec.Names[i].Name,
 				Package: sp.PackageName,
@@ -208,7 +229,11 @@ func (sp *Parser) ParseValueSpec(spec *ast.ValueSpec) ([]*gotypes.SymbolDef, err
 
 	for i := vLen; i < nLen; i++ {
 		if typeDef == nil {
-			return nil, fmt.Errorf("No type in ValueSpec declaration for identifier at pos %v (starting index from 1)", i+1)
+			// Assuming the line is preceded by iota
+			if sp.lastConstType == nil {
+				return nil, fmt.Errorf("No type in ValueSpec declaration for identifier at pos %v (starting index from 1)", i+1)
+			}
+			typeDef = sp.lastConstType
 		}
 		if spec.Names[i].Name == "_" {
 			continue
@@ -245,8 +270,9 @@ func (sp *Parser) parseDeclStmt(statement *ast.DeclStmt) error {
 				glog.Infof("Processing type spec declaration %#v\n", genDeclSpec)
 
 				if err := sp.SymbolTable.AddDataType(&gotypes.SymbolDef{
-					Name:    genDeclSpec.Name.Name,
-					Package: "",
+					Name: genDeclSpec.Name.Name,
+					// local variable has package origin as well (though the symbol gets dropped later on)
+					Package: sp.PackageName,
 					Def:     nil,
 				}); err != nil {
 					return err
@@ -262,7 +288,7 @@ func (sp *Parser) parseDeclStmt(statement *ast.DeclStmt) error {
 
 				if err := sp.SymbolTable.AddDataType(&gotypes.SymbolDef{
 					Name:    genDeclSpec.Name.Name,
-					Package: "",
+					Package: sp.PackageName,
 					Def:     typeDef,
 				}); err != nil {
 					return err
@@ -279,7 +305,7 @@ func (sp *Parser) parseDeclStmt(statement *ast.DeclStmt) error {
 }
 
 func (sp *Parser) parseLabeledStmt(statement *ast.LabeledStmt) error {
-	glog.Infof("Processing labeled statement  %#v\n", statement)
+	glog.Infof("Processing labeled %q statement %#v\n", statement.Label.Name, statement)
 	// the label is typeless
 	return sp.Parse(statement.Stmt)
 }
@@ -350,7 +376,7 @@ func (sp *Parser) parseAssignStmt(statement *ast.AssignStmt) error {
 			rExprSize = len(callExprDef)
 		case *ast.IndexExpr:
 			if exprsSize != 2 {
-				return fmt.Errorf("Expecting two expression on the RHS when accessing an index expression for for val, ok = indexexpr[key], got %#v instead", statement.Lhs)
+				return fmt.Errorf("Expecting two expression on the RHS when accessing an index expression for val, ok = indexexpr[key], got %#v instead", statement.Lhs)
 			}
 			xDef, err := sp.ExprParser.Parse(typeExpr.X)
 			if err != nil {
@@ -372,8 +398,33 @@ func (sp *Parser) parseAssignStmt(statement *ast.AssignStmt) error {
 				return nil, fmt.Errorf("Rhs index %v out of range", i)
 			}
 			rExprSize = 2
+		case *ast.TypeAssertExpr:
+			if exprsSize != 2 {
+				return fmt.Errorf("Expecting two expression on the RHS when type-asserting an expression for val, ok = expr.(datatype), got %#v instead", statement.Lhs)
+			}
+			xDef, err := sp.ExprParser.Parse(typeExpr.X)
+			if err != nil {
+				return err
+			}
+			if len(xDef) != 1 {
+				return fmt.Errorf("Index expression is not a single expression: %#v", xDef)
+			}
+			typeDef, err := sp.TypeParser.Parse(typeExpr.Type)
+			if err != nil {
+				return err
+			}
+			rhsIndexer = func(i int) (gotypes.DataType, error) {
+				if i == 0 {
+					return typeDef, nil
+				}
+				if i == 1 {
+					return &gotypes.Builtin{Def: "bool"}, nil
+				}
+				return nil, fmt.Errorf("Rhs index %v out of range", i)
+			}
+			rExprSize = 2
 		default:
-			panic(fmt.Errorf("Expecting callExpr, got %#v instead", statement.Rhs[0]))
+			panic(fmt.Errorf("Expecting *ast.CallExpr or *ast.IndexExpr, got %#v instead", statement.Rhs[0]))
 		}
 	}
 
@@ -518,7 +569,7 @@ func (sp *Parser) parseTypeSwitchStmt(statement *ast.TypeSwitchStmt) error {
 			return fmt.Errorf("Expecting type assert in type switch assignemnt statement")
 		}
 		if typeAssert.Type != nil {
-			fmt.Printf("type assert type is not set to literal 'type'. It is %#v instead\n", typeAssert.Type)
+			glog.Warningf("type assert type is not set to literal 'type'. It is %#v instead\n", typeAssert.Type)
 		}
 		if _, err := sp.ExprParser.Parse(typeAssert.X); err != nil {
 			return nil
@@ -540,7 +591,7 @@ func (sp *Parser) parseTypeSwitchStmt(statement *ast.TypeSwitchStmt) error {
 			return fmt.Errorf("Expecting type assert in type switch")
 		}
 		if typeAssert.Type != nil {
-			fmt.Printf("type assert type is not set to literal 'type'. It is %#v instead\n", typeAssert.Type)
+			glog.Warningf("type assert type is not set to literal 'type'. It is %#v instead\n", typeAssert.Type)
 		}
 		if _, err := sp.ExprParser.Parse(typeAssert.X); err != nil {
 			return nil
@@ -669,8 +720,8 @@ func (sp *Parser) parseSelectStmt(statement *ast.SelectStmt) error {
 						}
 						sp.SymbolTable.AddVariable(&gotypes.SymbolDef{
 							Name:    ident.Name,
-							Package: "",
-							Def:     rhsChannel,
+							Package: sp.PackageName,
+							Def:     rhsChannel.Value,
 						})
 					}
 				case 2:
@@ -750,7 +801,7 @@ func (sp *Parser) parseForStmt(statement *ast.ForStmt) error {
 
 // RangeClause = [ ExpressionList "=" | IdentifierList ":=" ] "range" Expression .
 func (sp *Parser) parseRangeStmt(statement *ast.RangeStmt) error {
-	glog.Infof("Processing range statement  %#v\n", statement)
+	glog.Infof("Processing range statement  %#v with token %v\n", statement, token.DEFINE)
 	// If the assignment is = all expression on the LHS are already defined.
 	// If the assignment is := all expression on the LHS are identifiers
 	xExpr, err := sp.ExprParser.Parse(statement.X)
@@ -763,6 +814,30 @@ func (sp *Parser) parseRangeStmt(statement *ast.RangeStmt) error {
 
 	if statement.Tok == token.DEFINE {
 
+		var rangeExpr gotypes.DataType
+		// over-approximation but given we run the go build before the procesing
+		// this is a valid processing
+		pointer, ok := xExpr[0].(*gotypes.Pointer)
+		if ok {
+			rangeExpr = pointer.Def
+		} else {
+			rangeExpr = xExpr[0]
+		}
+
+		// Identifier or a qid.Identifier
+		switch typeExpr := rangeExpr.(type) {
+		case *gotypes.Identifier:
+			def, defType, err := sp.Lookup(typeExpr)
+			if err != nil {
+				return err
+			}
+			if !defType.IsDataType() {
+				return fmt.Errorf("Expecting identifier of a ata type, got %#v instead", defType)
+			}
+			rangeExpr = def.Def
+			// TODO(jchaloup): cover selector as well
+		}
+
 		var key, value gotypes.DataType
 		// From https://golang.org/ref/spec#For_range
 		//
@@ -772,7 +847,7 @@ func (sp *Parser) parseRangeStmt(statement *ast.RangeStmt) error {
 		// string          s  string type            index    i  int    see below  rune
 		// map             m  map[K]V                key      k  K      m[k]       V
 		// channel         c  chan E, <-chan E       element  e  E
-		switch xExprType := xExpr[0].(type) {
+		switch xExprType := rangeExpr.(type) {
 		case *gotypes.Array:
 			key = &gotypes.Builtin{Def: "int"}
 			value = xExprType.Elmtype
@@ -790,8 +865,11 @@ func (sp *Parser) parseRangeStmt(statement *ast.RangeStmt) error {
 			value = xExprType.Valuetype
 		case *gotypes.Channel:
 			key = xExprType.Value
+		case *gotypes.Ellipsis:
+			key = &gotypes.Builtin{Def: "int"}
+			value = xExprType.Def
 		default:
-			panic(fmt.Errorf("Unknown type of range expression: %#v", xExpr[0]))
+			panic(fmt.Errorf("Unknown type of range expression: %#v", rangeExpr))
 		}
 
 		if statement.Key != nil {
@@ -799,6 +877,7 @@ func (sp *Parser) parseRangeStmt(statement *ast.RangeStmt) error {
 			if !ok {
 				return fmt.Errorf("Expected key as an identifier in the for range statement. Got %#v instead.", statement.Key)
 			}
+			glog.Infof("Processing range.Key variable %v", keyIdent.Name)
 
 			if keyIdent.Name != "_" {
 				if err := sp.SymbolTable.AddVariable(&gotypes.SymbolDef{
@@ -816,7 +895,7 @@ func (sp *Parser) parseRangeStmt(statement *ast.RangeStmt) error {
 			if !ok {
 				return fmt.Errorf("Expected value as an identifier in the for range statement. Got %#v instead.", statement.Value)
 			}
-
+			glog.Infof("Processing range.Value variable %v", valueIdent.Name)
 			if valueIdent.Name != "_" && value != nil {
 				if err := sp.SymbolTable.AddVariable(&gotypes.SymbolDef{
 					Name:    valueIdent.Name,
@@ -851,13 +930,9 @@ func (sp *Parser) parseIfStmt(statement *ast.IfStmt) error {
 
 	// The Init part is basically another block
 	if statement.Init != nil {
-		// The Init part must be an assignment statement
-		if _, ok := statement.Init.(*ast.AssignStmt); !ok {
-			return fmt.Errorf("If Init part must by an assignment statement if set")
-		}
 		sp.SymbolTable.Push()
 		defer sp.SymbolTable.Pop()
-		if err := sp.parseAssignStmt(statement.Init.(*ast.AssignStmt)); err != nil {
+		if err := sp.Parse(statement.Init); err != nil {
 			return err
 		}
 	}
@@ -868,8 +943,13 @@ func (sp *Parser) parseIfStmt(statement *ast.IfStmt) error {
 	}
 
 	// Process the If-body
-	sp.parseBlockStmt(statement.Body)
+	if err := sp.parseBlockStmt(statement.Body); err != nil {
+		return err
+	}
 
+	if statement.Else != nil {
+		return sp.Parse(statement.Else)
+	}
 	return nil
 }
 
@@ -937,6 +1017,8 @@ func (sp *Parser) Parse(statement ast.Stmt) error {
 		return sp.parseRangeStmt(stmtExpr)
 	case *ast.DeferStmt:
 		return sp.parseDeferStmt(stmtExpr)
+	case *ast.EmptyStmt:
+		return nil
 	default:
 		panic(fmt.Errorf("Unknown statement %#v", statement))
 	}

--- a/pkg/parser/symboltable/stack/stack.go
+++ b/pkg/parser/symboltable/stack/stack.go
@@ -102,6 +102,56 @@ func (s *Stack) LookupMethod(datatype, methodName string) (*gotypes.SymbolDef, e
 	return nil, fmt.Errorf("Method %q of data type %q not found", methodName, datatype)
 }
 
+func (s *Stack) LookupFunction(name string) (*gotypes.SymbolDef, error) {
+	glog.Infof("====Looking up a function %q", name)
+	// The top most item on the stack is the right most item in the simpleSlice
+	for i := s.Size - 1; i >= 0; i-- {
+		def, err := s.Tables[i].LookupFunction(name)
+		if err == nil {
+			return def, nil
+		}
+	}
+	return nil, fmt.Errorf("Symbol %v not found", name)
+}
+
+func (s *Stack) LookupDataType(name string) (*gotypes.SymbolDef, error) {
+	glog.Infof("====Looking up a data type %q", name)
+	// The top most item on the stack is the right most item in the simpleSlice
+	for i := s.Size - 1; i >= 0; i-- {
+		def, err := s.Tables[i].LookupDataType(name)
+		if err == nil {
+			return def, nil
+		}
+	}
+	return nil, fmt.Errorf("Symbol %v not found", name)
+}
+
+func (s *Stack) LookupVariableLikeSymbol(name string) (*gotypes.SymbolDef, error) {
+	glog.Infof("====Looking up a variablelike %q", name)
+	// The top most item on the stack is the right most item in the simpleSlice
+	for i := s.Size - 1; i >= 0; i-- {
+		def, err := s.Tables[i].LookupVariableLikeSymbol(name)
+		if err == nil {
+			return def, nil
+		}
+	}
+	// if the variable is not found, check the qids
+	if def, ok := s.Imports[name]; ok {
+		return def, nil
+	}
+	return nil, fmt.Errorf("VariableLike Symbol %v not found", name)
+}
+
+func (s *Stack) Exists(name string) bool {
+	if _, _, err := s.Lookup(name); err == nil {
+		return true
+	}
+	if _, ok := s.Imports[name]; ok {
+		return true
+	}
+	return false
+}
+
 // Lookup looks for the first occurrence of a symbol with the given name
 func (s *Stack) Lookup(name string) (*gotypes.SymbolDef, symboltable.SymbolType, error) {
 	// The top most item on the stack is the right most item in the simpleSlice

--- a/pkg/parser/symboltable/stack/stack.go
+++ b/pkg/parser/symboltable/stack/stack.go
@@ -68,7 +68,7 @@ func (s *Stack) AddDataType(sym *gotypes.SymbolDef) error {
 }
 
 func (s *Stack) AddFunction(sym *gotypes.SymbolDef) error {
-	glog.Infof("Adding function %q as: %#v", sym.Name, sym.Def)
+	glog.Infof("====Adding function %q as: %#v", sym.Name, sym.Def)
 	if s.Size > 0 {
 		return s.Tables[s.Size-1].AddFunction(sym)
 	}
@@ -76,6 +76,7 @@ func (s *Stack) AddFunction(sym *gotypes.SymbolDef) error {
 }
 
 func (s *Stack) LookupVariable(name string) (*gotypes.SymbolDef, error) {
+	glog.Infof("====Looking up a variable %q", name)
 	// The top most item on the stack is the right most item in the simpleSlice
 	for i := s.Size - 1; i >= 0; i-- {
 		def, err := s.Tables[i].LookupVariable(name)

--- a/pkg/parser/type/type_parser.go
+++ b/pkg/parser/type/type_parser.go
@@ -263,15 +263,21 @@ func (p *Parser) parseFunction(typedExpr *ast.FuncType) (*gotypes.Function, erro
 	var results []gotypes.DataType
 
 	if typedExpr.Params != nil {
+		glog.Infof("len(typedExpr.Params.List): %#v\n", len(typedExpr.Params.List))
 		for _, field := range typedExpr.Params.List {
+			glog.Infof("Processing field.Type: %#v\n", field.Type)
 			def, err := p.Parse(field.Type)
 			if err != nil {
 				return nil, err
 			}
-
+			glog.Infof("Processing field.Names: %#v\n", field.Names)
 			// field.Names list must be singletion at least
-			for i := 0; i < len(field.Names); i++ {
+			if len(field.Names) == 0 {
 				params = append(params, def)
+			} else {
+				for i := 0; i < len(field.Names); i++ {
+					params = append(params, def)
+				}
 			}
 		}
 
@@ -287,7 +293,7 @@ func (p *Parser) parseFunction(typedExpr *ast.FuncType) (*gotypes.Function, erro
 				return nil, err
 			}
 
-			// results can be identifier free
+			// results can be iderigin="buntifier free
 			if len(field.Names) == 0 {
 				results = append(results, def)
 			} else {
@@ -329,7 +335,7 @@ func (p *Parser) Parse(expr ast.Expr) (gotypes.DataType, error) {
 	case *ast.FuncType:
 		return p.parseFunction(typedExpr)
 	}
-	return nil, fmt.Errorf("ast.Expr (%#v) not recognized", expr)
+	return nil, fmt.Errorf("ast.Expr (%#v) not recognized when parsing a type definition", expr)
 }
 
 // New creates an instance of the type Parser

--- a/pkg/parser/types/types.go
+++ b/pkg/parser/types/types.go
@@ -88,3 +88,31 @@ func (c *Config) Lookup(ident *gotypes.Identifier) (*gotypes.SymbolDef, symbolta
 	}
 	return table.Lookup(ident.Def)
 }
+
+func (c *Config) LookupMethod(ident *gotypes.Identifier, method string) (*gotypes.SymbolDef, error) {
+	if ident.Package == "" {
+		return nil, fmt.Errorf("Identifier %#v does not set its Package field", ident)
+	}
+	if ident.Package == c.PackageName {
+		return c.SymbolTable.LookupMethod(ident.Def, method)
+	}
+	table, err := c.GlobalSymbolTable.Lookup(ident.Package)
+	if err != nil {
+		return nil, err
+	}
+	return table.LookupMethod(ident.Def, method)
+}
+
+func (c *Config) LookupDataType(ident *gotypes.Identifier) (*gotypes.SymbolDef, error) {
+	if ident.Package == "" {
+		return nil, fmt.Errorf("Identifier %#v does not set its Package field", ident)
+	}
+	if ident.Package == c.PackageName {
+		return c.SymbolTable.LookupDataType(ident.Def)
+	}
+	table, err := c.GlobalSymbolTable.Lookup(ident.Package)
+	if err != nil {
+		return nil, err
+	}
+	return table.LookupDataType(ident.Def)
+}


### PR DESCRIPTION
- add more info logging messages to help capture the processing flow
- process function declaration of postponed functions before processing of postponed variables
- get list of files to process via `go list -f "{{.GoFiles}}" PACKAGENAME` command
- keep data type of the last constant item in case following items are typeless
- set origin of locally set variables as well (it will get dropped anyway and is needed in some decision logic) + iota
- extend assigments with "value, ok := map[value]" and "value, ok := pointer.(type)" constructs
- extend range over pointer types and ellipsis
- FIX: parse else block of if statement as well (it was not processed at all previously)
- add additional Lookup functions (e.g. LookupFunction, LookupDataType, LookupVariableLikeSymbol) to simplify expression processing logic and make it more clear on what is actually looked up, Introduce Exists method to check if a symbol of any available type actually exists
- FIX: when adding a method generate the name in form of datatype.methodname
- FIX: when a function parameter name is ommited, store its data type
- extend processing with additional unary and binary operators
- SHL and SHR operators have different rules of what data is of operands is allowed and what data type is returned
- take into accout byte = uint8 when checking operands of a binary expression
- when looking up a variable/function, check for user defined ones first, then check for built-in variables/functions
- processed "make" and "new" builtin functions differently from the remaining ones (i.e. return proper type)
- when retrieving struct fields, check fields and methods of embedded structs as well
- and many more (sorry there is so many minor fixes)