### PR TITLE
process all value specs iteratively per package

### DIFF
--- a/pkg/parser/expression/expression_parser.go
+++ b/pkg/parser/expression/expression_parser.go
@@ -159,6 +159,7 @@ func (ep *Parser) parseCompositeLitStructElements(lit *ast.CompositeLit, structD
 }
 
 func (ep *Parser) parseCompositeLitElements(lit *ast.CompositeLit, symbolDef *gotypes.SymbolDef) error {
+	glog.Infof("Processing parseCompositeLitElements symbolDef: %#v", symbolDef)
 	switch clTypeDataType := symbolDef.Def.(type) {
 	case *gotypes.Struct:
 		if err := ep.parseCompositeLitStructElements(lit, clTypeDataType, symbolDef); err != nil {
@@ -177,7 +178,7 @@ func (ep *Parser) parseCompositeLitElements(lit *ast.CompositeLit, symbolDef *go
 			return err
 		}
 	default:
-		return fmt.Errorf("Unsupported 2 ClTypeIdentifierDef: %#v\n", symbolDef)
+		return fmt.Errorf("Unsupported 2 type %#v in ClTypeIdentifierDef of %#v\n", symbolDef.Def, symbolDef)
 	}
 	return nil
 }


### PR DESCRIPTION
Given a variable type can be determined after its value is fully processed,
variable type does not have to known at file scope.
Some variables may reference data types or variable like symbols from other files
of the same package. Thus, the value spec processing must be carried on a package level.

E.g. check unicode package from stdlib