### PR TITLE
set implicit data type and value of consts

### DIFF
--- a/pkg/parser/file/parser_test.go
+++ b/pkg/parser/file/parser_test.go
@@ -29,7 +29,10 @@ func parseBuiltin(config *parsertypes.Config) error {
 		return fmt.Errorf("AST Parse error: %v", err)
 	}
 
-	payload := MakePayload(f)
+	payload, err := MakePayload(f)
+	if err != nil {
+		return err
+	}
 	if err := NewParser(config).Parse(payload); err != nil {
 		return fmt.Errorf("Unable to parse file %v: %v", gofile, err)
 	}
@@ -86,7 +89,10 @@ func TestDataTypes(t *testing.T) {
 	config.ExprParser = exprparser.New(config)
 	config.StmtParser = stmtparser.New(config)
 
-	payload := MakePayload(f)
+	payload, err := MakePayload(f)
+	if err != nil {
+		t.Errorf("Unable to make a payload due to: %v", err)
+	}
 	if err := NewParser(config).Parse(payload); err != nil {
 		t.Errorf("Unable to parse file %v: %v", gofile, err)
 	}

--- a/pkg/parser/parser.go
+++ b/pkg/parser/parser.go
@@ -452,7 +452,10 @@ PACKAGE_STACK:
 			if err := p.Config.SymbolTable.Reset(); err != nil {
 				panic(err)
 			}
-			payload := fileparser.MakePayload(fileContext.FileAST)
+			payload, err := fileparser.MakePayload(fileContext.FileAST)
+			if err != nil {
+				return fmt.Errorf("Unable to create a payload: %v", err)
+			}
 			p.Config.AllocatedSymbolsTable = fileContext.AllocatedSymbolsTable
 			if err := fileparser.NewParser(p.Config).Parse(payload); err != nil {
 				return err


### PR DESCRIPTION
So `B` and `C` have proper type in
```go
const (
    A float64 = iota
    B
    C
)
```