### PR TITLE
ignore Type from builtin package

### DIFF
--- a/pkg/parser/type/type_parser.go
+++ b/pkg/parser/type/type_parser.go
@@ -48,7 +48,7 @@ func (p *Parser) parseIdentifier(typedExpr *ast.Ident) (gotypes.DataType, error)
 	// it is allocated.
 
 	// Check if the identifier is a built-in type
-	if p.Config.IsBuiltin(typedExpr.Name) {
+	if typedExpr.Name != "Type" && p.Config.IsBuiltin(typedExpr.Name) {
 		p.AllocatedSymbolsTable.AddSymbol("builtin", typedExpr.Name)
 		table, err := p.GlobalSymbolTable.Lookup("builtin")
 		if err != nil {


### PR DESCRIPTION
Given the Type as actually ordinary interface in reflect package,
it needs to be treated accordingly.

Fixes: #44 