### PR TITLE
store and load symbol tables to/from a directory

### DIFF
--- a/golang-project-exported-api.json
+++ b/golang-project-exported-api.json
@@ -175,11 +175,11 @@
 				},
 				"package": {
 					"type": "string",
-					"description": "!!omit",
+					"description": "Symbol origin",
 					"minLength": 1
 				}
 			},
-			"required": ["type", "def"]
+			"required": ["type", "def", "package"]
 		},
 		"packagequalifier": {
 			"type": "object",
@@ -586,14 +586,16 @@
 						"properties": {
 							"name": {
 								"type": "string",
-								"description": "Method name",
-								"minLength": 1
+								"description": "Method name"
 							},
 							"def": {
 								"type": "object",
 								"description": "Function type definition",
 								"oneOf": [
-									{ "$ref": "#/definitions/function" }
+									{ "$ref": "#/definitions/function" },
+									{ "$ref": "#/definitions/identifier" },
+									{ "$ref": "#/definitions/selector" },
+									{ "$ref": "#/definitions/pointer" }
 								]
 							}
 						},

--- a/pkg/parser/expression/expression_parser.go
+++ b/pkg/parser/expression/expression_parser.go
@@ -1142,7 +1142,7 @@ func (ep *Parser) retrieveInterfaceMethod(pkgsymboltable symboltable.SymbolLooka
 				embeddedInterfaces = append(embeddedInterfaces, embeddedInterfacesItem{symbolTable: st, symbolDef: sd})
 				continue
 			default:
-				panic(fmt.Errorf("Unknown anonymous field type %#v", item.Def))
+				panic(fmt.Errorf("Unknown anonymous field type %#v", item))
 			}
 		}
 		if methodName == method {

--- a/pkg/parser/parser_test.go
+++ b/pkg/parser/parser_test.go
@@ -11,7 +11,7 @@ import (
 )
 
 func TestProjectParser(t *testing.T) {
-	pp := New("github.com/gofed/symbols-extractor/pkg/parser/testdata/unordered")
+	pp := New("github.com/gofed/symbols-extractor/pkg/parser/testdata/unordered", "")
 	if err := pp.Parse(); err != nil {
 		t.Errorf("Parse error: %v", err)
 	}

--- a/pkg/parser/statement/statement_parser.go
+++ b/pkg/parser/statement/statement_parser.go
@@ -647,7 +647,8 @@ func (sp *Parser) parseTypeSwitchStmt(statement *ast.TypeSwitchStmt) error {
 
 		if ident.Name != "_" {
 			rhsIdentifier = &gotypes.Identifier{
-				Def: ident.Name,
+				Def:     ident.Name,
+				Package: sp.PackageName,
 			}
 		}
 	case *ast.ExprStmt:
@@ -959,7 +960,7 @@ func (sp *Parser) parseRangeStmt(statement *ast.RangeStmt) error {
 			if keyIdent.Name != "_" {
 				if err := sp.SymbolTable.AddVariable(&gotypes.SymbolDef{
 					Name:    keyIdent.Name,
-					Package: "",
+					Package: sp.PackageName,
 					Def:     key,
 				}); err != nil {
 					return err
@@ -976,7 +977,7 @@ func (sp *Parser) parseRangeStmt(statement *ast.RangeStmt) error {
 			if valueIdent.Name != "_" && value != nil {
 				if err := sp.SymbolTable.AddVariable(&gotypes.SymbolDef{
 					Name:    valueIdent.Name,
-					Package: "",
+					Package: sp.PackageName,
 					Def:     value,
 				}); err != nil {
 					return err

--- a/pkg/parser/symboltable/global/global.go
+++ b/pkg/parser/symboltable/global/global.go
@@ -1,9 +1,15 @@
 package global
 
 import (
+	"encoding/json"
 	"fmt"
+	"io/ioutil"
+	"os"
+	"path"
+	"strings"
 
 	"github.com/gofed/symbols-extractor/pkg/parser/symboltable"
+	"github.com/golang/glog"
 )
 
 type Table struct {
@@ -16,6 +22,11 @@ func (t *Table) Lookup(pkg string) (*symboltable.Table, error) {
 		return nil, fmt.Errorf("Unable to find symbol table for %q", pkg)
 	}
 	return table, nil
+}
+
+func (t *Table) Exists(pkg string) bool {
+	_, ok := t.tables[pkg]
+	return ok
 }
 
 func (t *Table) Add(pkg string, st *symboltable.Table) error {
@@ -39,4 +50,50 @@ func New() *Table {
 	return &Table{
 		tables: make(map[string]*symboltable.Table, 0),
 	}
+}
+
+func (t *Table) Save(symboltabledir string) error {
+	for key, symbolTable := range t.tables {
+		file := path.Join(symboltabledir, fmt.Sprintf("%v.json", strings.Replace(key, "/", ".", -1)))
+		if _, err := os.Stat(file); err == nil {
+			continue
+		}
+		byteSlice, err := json.Marshal(symbolTable)
+		if err != nil {
+			return fmt.Errorf("Unable to save %q symbol table: %v", key, err)
+		}
+
+		if err := ioutil.WriteFile(file, byteSlice, 0644); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (t *Table) Load(symboltabledir string) error {
+	t.tables = make(map[string]*symboltable.Table, 0)
+
+	files, err := ioutil.ReadDir(symboltabledir)
+	if err != nil {
+		return err
+	}
+	for _, f := range files {
+		file := path.Join(symboltabledir, f.Name())
+		glog.Infof("Loading %q", file)
+		raw, err := ioutil.ReadFile(file)
+		if err != nil {
+			return err
+		}
+
+		parts := strings.Split(f.Name(), ".")
+		name := strings.Join(parts[:len(parts)-1], "/")
+		var table symboltable.Table
+		if err := json.Unmarshal(raw, &table); err != nil {
+			return nil
+		}
+		t.tables[name] = &table
+		fmt.Printf("Symbol table %q loaded\n", name)
+	}
+
+	return nil
 }

--- a/pkg/parser/symboltable/table.go
+++ b/pkg/parser/symboltable/table.go
@@ -83,6 +83,8 @@ func (t *Table) UnmarshalJSON(b []byte) error {
 		DataTypeSymbol: make(map[string]*gotypes.SymbolDef, 0),
 	}
 
+	t.methods = make(map[string]map[string]*gotypes.SymbolDef)
+
 	for _, symbolType := range SymbolTypes {
 		if objMap[symbolType] != nil {
 			var m []*gotypes.SymbolDef
@@ -93,7 +95,13 @@ func (t *Table) UnmarshalJSON(b []byte) error {
 			t.Symbols[symbolType] = m
 
 			for _, item := range m {
-				t.symbols[symbolType][item.Name] = item
+				if symbolType == FunctionSymbol {
+					if err := t.AddFunction(item); err != nil {
+						return err
+					}
+				} else {
+					t.symbols[symbolType][item.Name] = item
+				}
 			}
 		}
 	}

--- a/pkg/types/types.go
+++ b/pkg/types/types.go
@@ -50,7 +50,6 @@ func (o *Function) UnmarshalJSON(b []byte) error {
 				if err := json.Unmarshal(*item, &m); err != nil {
 					return err
 				}
-
 				switch dataType := m["type"]; dataType {
 
 				case IdentifierType:
@@ -163,7 +162,6 @@ func (o *Function) UnmarshalJSON(b []byte) error {
 				if err := json.Unmarshal(*item, &m); err != nil {
 					return err
 				}
-
 				switch dataType := m["type"]; dataType {
 
 				case IdentifierType:
@@ -793,8 +791,14 @@ func (o *Struct) UnmarshalJSON(b []byte) error {
 				if err := json.Unmarshal(*item, &m); err != nil {
 					return err
 				}
-
 				switch dataType := m["type"]; dataType {
+
+				case StructFieldsItemType:
+					r := &StructFieldsItem{}
+					if err := json.Unmarshal(*item, &r); err != nil {
+						return err
+					}
+					o.Fields = append(o.Fields, *r)
 
 				}
 			}
@@ -1093,6 +1097,27 @@ func (o *InterfaceMethodsItem) UnmarshalJSON(b []byte) error {
 				}
 				o.Def = r
 
+			case IdentifierType:
+				r := &Identifier{}
+				if err := json.Unmarshal(*objMap["def"], &r); err != nil {
+					return err
+				}
+				o.Def = r
+
+			case SelectorType:
+				r := &Selector{}
+				if err := json.Unmarshal(*objMap["def"], &r); err != nil {
+					return err
+				}
+				o.Def = r
+
+			case PointerType:
+				r := &Pointer{}
+				if err := json.Unmarshal(*objMap["def"], &r); err != nil {
+					return err
+				}
+				o.Def = r
+
 			}
 		}
 	}
@@ -1142,8 +1167,14 @@ func (o *Interface) UnmarshalJSON(b []byte) error {
 				if err := json.Unmarshal(*item, &m); err != nil {
 					return err
 				}
-
 				switch dataType := m["type"]; dataType {
+
+				case InterfaceMethodsItemType:
+					r := &InterfaceMethodsItem{}
+					if err := json.Unmarshal(*item, &r); err != nil {
+						return err
+					}
+					o.Methods = append(o.Methods, *r)
 
 				}
 			}
@@ -1415,7 +1446,7 @@ const IdentifierType = "identifier"
 
 type Identifier struct {
 	Def     string `json:"def"`
-	Package string `json:"-"`
+	Package string `json:"package"`
 }
 
 func (o *Identifier) GetType() string {
@@ -1442,6 +1473,11 @@ func (o *Identifier) UnmarshalJSON(b []byte) error {
 
 	// TODO(jchaloup): check the objMap["def"] actually exists
 	if err := json.Unmarshal(*objMap["def"], &o.Def); err != nil {
+		return err
+	}
+
+	// TODO(jchaloup): check the objMap["package"] actually exists
+	if err := json.Unmarshal(*objMap["package"], &o.Package); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
To speed up scanning don't re-process packages that are already processed.