### PR TITLE
refactor composite literal processing

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,9 +1,17 @@
+all:
+	go build  -o extract github.com/gofed/symbols-extractor/cmd
+
 test:
-	go test -v github.com/gofed/symbols-extractor/pkg/parser
-	go test -v github.com/gofed/symbols-extractor/pkg/parser/file
+	#go test -v github.com/gofed/symbols-extractor/pkg/parser #-stderrthreshold=INFO
+	go test -v github.com/gofed/symbols-extractor/pkg/parser/file #-stderrthreshold=INFO
 	go test -v github.com/gofed/symbols-extractor/pkg/types
-	go test -v github.com/gofed/symbols-extractor/pkg/parser/expression
-	go test -v github.com/gofed/symbols-extractor/pkg/parser/statement
+	go test -v github.com/gofed/symbols-extractor/pkg/parser/expression #-stderrthreshold=INFO
+	go test -v github.com/gofed/symbols-extractor/pkg/parser/statement #-stderrthreshold=INFO
 
 gen:
 	./gentypes.sh
+
+clean:
+	rm extract
+	rm -f symboltables/*
+


### PR DESCRIPTION
Given a composite literal can by a data type of a different package, one can no longer replace missing composite literal data type with an `ast.Expr`. E.g.
```go
type A []pkg.Type

a := A{
    {
        ...
    },
}
```