### PR TITLE
Minox fixes

### DIFF
--- a/golang-project-exported-api.json
+++ b/golang-project-exported-api.json
@@ -594,6 +594,7 @@
 								"oneOf": [
 									{ "$ref": "#/definitions/function" },
 									{ "$ref": "#/definitions/identifier" },
+									{ "$ref": "#/definitions/builtin" },
 									{ "$ref": "#/definitions/selector" },
 									{ "$ref": "#/definitions/pointer" }
 								]

--- a/pkg/parser/expression/expression_parser.go
+++ b/pkg/parser/expression/expression_parser.go
@@ -1134,6 +1134,9 @@ func (ep *Parser) retrieveInterfaceMethod(pkgsymboltable symboltable.SymbolLooka
 		if methodName == "" {
 			// Given a variable can be of interface data type,
 			// embedded interface needs to be checked as well.
+			if item.Def == nil {
+				return nil, fmt.Errorf("Symbol of embedded interface not fully processed")
+			}
 			itemExpr := item.Def
 			if pointerExpr, isPointer := item.Def.(*gotypes.Pointer); isPointer {
 				itemExpr = pointerExpr.Def
@@ -1254,7 +1257,7 @@ func (ep *Parser) checkAngGetDataTypeMethod(expr *ast.SelectorExpr) (bool, *goty
 }
 
 func (ep *Parser) parseSelectorExpr(expr *ast.SelectorExpr) (gotypes.DataType, error) {
-	glog.Infof("Processing SelectorExpr: %#v\n", expr)
+	glog.Infof("Processing SelectorExpr: %#v at %v\n", expr, expr.Pos())
 	// Check for data type method cases
 	// (*Receiver).method: use method of a data type as a value to store to a variable
 	// (Receiver).method: the same, just the receiver is a data type itself

--- a/pkg/parser/statement/statement_parser.go
+++ b/pkg/parser/statement/statement_parser.go
@@ -545,6 +545,13 @@ func (sp *Parser) parseAssignStmt(statement *ast.AssignStmt) error {
 		glog.Infof("Assignment LHs[%v]: %#v\n", i, statement.Lhs[i])
 		glog.Infof("Assignment RHs[%v]: %#v\n", i, rhsExpr)
 
+		// Skip parenthesis
+		parExpr, ok := statement.Lhs[i].(*ast.ParenExpr)
+		for ok {
+			statement.Lhs[i] = parExpr.X
+			parExpr, ok = statement.Lhs[i].(*ast.ParenExpr)
+		}
+
 		switch lhsExpr := statement.Lhs[i].(type) {
 		case *ast.Ident:
 			// skip the anonymous variables

--- a/pkg/parser/statement/statement_parser.go
+++ b/pkg/parser/statement/statement_parser.go
@@ -935,21 +935,11 @@ func (sp *Parser) parseRangeStmt(statement *ast.RangeStmt) error {
 		}
 
 		// Identifier or a qid.Identifier
-		switch typeExpr := rangeExpr.(type) {
-		case *gotypes.Identifier:
-			def, defType, err := sp.Lookup(typeExpr)
-			if err != nil {
-				return err
-			}
-			if !defType.IsDataType() {
-				return fmt.Errorf("Expecting identifier of a ata type, got %#v instead", defType)
-			}
-			if def.Def == nil {
-				return fmt.Errorf("Symbol %q not yet fully processed", def.Name)
-			}
-			rangeExpr = def.Def
-			// TODO(jchaloup): cover selector as well
+		rangeExpr, err := sp.Config.FindFirstNonidDataType(rangeExpr)
+		if err != nil {
+			return err
 		}
+
 		var key, value gotypes.DataType
 		// From https://golang.org/ref/spec#For_range
 		//
@@ -987,7 +977,7 @@ func (sp *Parser) parseRangeStmt(statement *ast.RangeStmt) error {
 			key = &gotypes.Builtin{Def: "int"}
 			value = xExprType.Def
 		default:
-			panic(fmt.Errorf("Unknown type of range expression: %#v", rangeExpr))
+			panic(fmt.Errorf("Unknown type of range expression: %#v at %v", rangeExpr, statement.Pos()))
 		}
 
 		if statement.Key != nil {

--- a/pkg/types/types.go
+++ b/pkg/types/types.go
@@ -1104,6 +1104,13 @@ func (o *InterfaceMethodsItem) UnmarshalJSON(b []byte) error {
 				}
 				o.Def = r
 
+			case BuiltinType:
+				r := &Builtin{}
+				if err := json.Unmarshal(*objMap["def"], &r); err != nil {
+					return err
+				}
+				o.Def = r
+
 			case SelectorType:
 				r := &Selector{}
 				if err := json.Unmarshal(*objMap["def"], &r); err != nil {


### PR DESCRIPTION
- skip parenthesis on LHS of an assignment
- extend a list of interface method item types with a builtin
- if a data type is defined via [qualified] identifier, continue retrieving data type definitions
- extend a list of isDataType recognized types
- fix datat type return from a channel
- extend "retrieve a field from data type" with selector