### PR TITLE
replace []gotypes.DataType with more general types.ExprAttribute

### DIFF
--- a/pkg/parser/expression/parser_test.go
+++ b/pkg/parser/expression/parser_test.go
@@ -92,10 +92,10 @@ func TestBinaryExpr(t *testing.T) {
 
 		if !testExpr[i].expectedError && err == nil {
 			// compare returned and expected value
-			if testExpr[i].expRes.GetType() != res.GetType() {
+			if testExpr[i].expRes.GetType() != res.DataTypeList[0].GetType() {
 				t.Errorf("Expected '%s' type, got '%s' instead. Line: '%s'",
 					testExpr[i].expRes.GetType(),
-					res.GetType(),
+					res.DataTypeList[0].GetType(),
 					testExpr[i].expr,
 				)
 				failed = true

--- a/pkg/parser/types/types.go
+++ b/pkg/parser/types/types.go
@@ -19,13 +19,19 @@ type TypeParser interface {
 }
 
 type ExprAttribute struct {
-	SymbolDefs []*gotypes.SymbolDef
+	DataTypeList []gotypes.DataType
 	// PropagationSequence []string
+}
+
+func ExprAttributeFromDataType(list ...gotypes.DataType) *ExprAttribute {
+	return &ExprAttribute{
+		DataTypeList: list,
+	}
 }
 
 // ExpressionParser implemenation is responsible for Go expression parsing/processing
 type ExpressionParser interface {
-	Parse(expr ast.Expr) ([]gotypes.DataType, error)
+	Parse(expr ast.Expr) (*ExprAttribute, error)
 }
 
 // StatementParser implemenation is responsible for:


### PR DESCRIPTION
Introducing new struct storing all attributes that can be extracted from an expression:

```go
type ExprAttribute struct {
	DataTypeList []gotypes.DataType
}
```

The change is a preparation for propagation sequence extraction.