### PR TITLE
Store the contracts per function body

### DIFF
--- a/pkg/parser/contracts/table/table.go
+++ b/pkg/parser/contracts/table/table.go
@@ -8,13 +8,16 @@ import (
 )
 
 type Table struct {
-	contracts              []contracts.Contract
+	contracts              map[string][]contracts.Contract
 	virtualVariableCounter int
 	prefix                 string
 }
 
 func (t *Table) AddContract(contract contracts.Contract) {
-	t.contracts = append(t.contracts, contract)
+	if _, ok := t.contracts[t.prefix]; !ok {
+		t.contracts[t.prefix] = make([]contracts.Contract, 0)
+	}
+	t.contracts[t.prefix] = append(t.contracts[t.prefix], contract)
 	glog.Infof("Adding contract: %v\n", contracts.Contract2String(contract))
 }
 
@@ -22,18 +25,26 @@ func (t *Table) SetPrefix(prefix string) {
 	t.prefix = prefix
 }
 
+func (t *Table) UnsetPrefix() {
+	t.prefix = ""
+}
+
+func (t *Table) DropPrefixContracts(prefix string) {
+	delete(t.contracts, prefix)
+}
+
 func (t *Table) NewVariable() string {
 	t.virtualVariableCounter++
 	return fmt.Sprintf("virtual.var.%v", t.virtualVariableCounter)
 }
 
-func (t *Table) Contracts() []contracts.Contract {
+func (t *Table) Contracts() map[string][]contracts.Contract {
 	return t.contracts
 }
 
 func New() *Table {
 	return &Table{
-		contracts:              make([]contracts.Contract, 0),
+		contracts:              make(map[string][]contracts.Contract, 0),
 		virtualVariableCounter: 0,
 	}
 }

--- a/tests/integration/contracts/utils.go
+++ b/tests/integration/contracts/utils.go
@@ -6,6 +6,7 @@ import (
 	"go/token"
 	"os"
 	"path"
+	"sort"
 	"testing"
 
 	"github.com/gofed/symbols-extractor/pkg/parser/contracts"
@@ -77,7 +78,17 @@ func ParseAndCompareContracts(t *testing.T, gopkg, filename string, tests []cont
 		t.Error(err)
 		return
 	}
-	CompareContracts(t, config.ContractTable.Contracts(), tests)
+	var genContracts []contracts.Contract
+	cs := config.ContractTable.Contracts()
+	var keys []string
+	for fncName := range cs {
+		keys = append(keys, fncName)
+	}
+	sort.Strings(keys)
+	for _, key := range keys {
+		genContracts = append(genContracts, cs[key]...)
+	}
+	CompareContracts(t, genContracts, tests)
 }
 
 func CompareContracts(t *testing.T, contractsList, tests []contracts.Contract) {


### PR DESCRIPTION
So we can drop contracts of a non fully processed function body.
So we can track per function contracts.