### PR TITLE
Introduce simple data type propagation runner

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -135,7 +135,8 @@ integration:
 			$(PROJECT_ROOT)/tests/integration/contracts/selectors  \
 			$(PROJECT_ROOT)/tests/integration/contracts/type_casting  \
 			$(PROJECT_ROOT)/tests/integration/contracts/unaryops \
-			$(PROJECT_ROOT)/tests/integration/contracts/multi_packages $(GLOG_FLAGS) $(WLOG)
+			$(PROJECT_ROOT)/tests/integration/contracts/multi_packages \
+			$(PROJECT_ROOT)/tests/integration/typepropagation $(GLOG_FLAGS) $(WLOG)
 
 gen:
 	./gentypes.sh

--- a/pkg/analyzers/type/runner/runner.go
+++ b/pkg/analyzers/type/runner/runner.go
@@ -1,0 +1,382 @@
+package runner
+
+import (
+	"fmt"
+
+	"github.com/gofed/symbols-extractor/pkg/analyzers/type/propagation"
+	"github.com/gofed/symbols-extractor/pkg/parser/contracts"
+	"github.com/gofed/symbols-extractor/pkg/parser/contracts/typevars"
+	"github.com/gofed/symbols-extractor/pkg/parser/types"
+	"github.com/gofed/symbols-extractor/pkg/symbols/accessors"
+	"github.com/gofed/symbols-extractor/pkg/symbols/tables/global"
+	gotypes "github.com/gofed/symbols-extractor/pkg/types"
+)
+
+type Runner struct {
+	v2c           *var2Contract
+	entryTypevars map[string]typevars.Interface
+	// data type propagation through virtual variables
+	*varTable
+
+	// contracts
+	waitingContracts *contractPayload
+
+	globalSymbolTable *global.Table
+
+	symbolAccessor *accessors.Accessor
+}
+
+func New(config *types.Config) *Runner {
+	r := &Runner{
+		v2c:               newVar2Contract(),
+		entryTypevars:     make(map[string]typevars.Interface, 0),
+		varTable:          newVarTable(),
+		waitingContracts:  newContractPayload(nil),
+		globalSymbolTable: config.GlobalSymbolTable,
+		symbolAccessor:    accessors.NewAccessor(config.GlobalSymbolTable),
+	}
+
+	st, err := config.GlobalSymbolTable.Lookup(config.PackageName)
+	if err != nil {
+		panic(err)
+	}
+
+	r.symbolAccessor.SetCurrentTable(config.PackageName, st)
+
+	storeVar := func(v *typevars.Variable, c contracts.Contract) {
+		// Allocate table of variables for data type propagation
+		r.varTable.SetVariable(v.String(), nil)
+		r.v2c.addVar(v.String(), c)
+		if v.Package != "" {
+			// Entry points are all global scope variables.
+			// Except for var a = ... cases where the type is not known (handled later).
+			r.entryTypevars[v.String()] = v
+		}
+	}
+
+	isVariable := func(i typevars.Interface) bool {
+		_, ok := i.(*typevars.Variable)
+		return ok
+	}
+
+	for funcName, cs := range config.ContractTable.Contracts() {
+		for _, c := range cs {
+			r.waitingContracts.addContract(funcName, c)
+			switch d := c.(type) {
+			case *contracts.UnaryOp:
+				if isVariable(d.X) {
+					storeVar(d.X.(*typevars.Variable), c)
+				}
+			case *contracts.BinaryOp:
+				if isVariable(d.X) {
+					storeVar(d.X.(*typevars.Variable), c)
+				}
+				if isVariable(d.Y) {
+					storeVar(d.Y.(*typevars.Variable), c)
+				}
+			case *contracts.HasField:
+				if isVariable(d.X) {
+					storeVar(d.X.(*typevars.Variable), c)
+				}
+			case *contracts.IsCompatibleWith:
+				if isVariable(d.X) {
+					storeVar(d.X.(*typevars.Variable), c)
+				}
+				if isVariable(d.Y) {
+					storeVar(d.Y.(*typevars.Variable), c)
+				}
+			case *contracts.PropagatesTo:
+				if isVariable(d.X) {
+					storeVar(d.X.(*typevars.Variable), c)
+				}
+				if isVariable(d.Y) {
+					storeVar(d.Y.(*typevars.Variable), c)
+				}
+			case *contracts.IsInvocable:
+				if isVariable(d.F) {
+					storeVar(d.F.(*typevars.Variable), c)
+				}
+			default:
+				panic(fmt.Sprintf("Unrecognized contract: %#v", c))
+			}
+		}
+	}
+
+	// Find all global variables that are on RHS of the PropagatesTo contract
+	// and remove them from the entry variables
+	for _, cs := range config.ContractTable.Contracts() {
+		for _, c := range cs {
+			if d, ok := c.(*contracts.PropagatesTo); ok {
+				if v, ok := d.Y.(*typevars.Variable); ok {
+					if v.Package != "" {
+						delete(r.entryTypevars, v.String())
+					}
+				}
+			}
+		}
+	}
+
+	return r
+}
+
+func (r *Runner) isTypevarEvaluated(i typevars.Interface) bool {
+	switch d := i.(type) {
+	case *typevars.Constant:
+		return true
+	case *typevars.Variable:
+		if r.varTable.GetVariable(d.String()) != nil {
+			return true
+		}
+		return false
+	case *typevars.Field:
+		if r.isTypevarEvaluated(d.X) {
+			_, exists := r.varTable.GetField(d.X.String(), d.Name)
+			return exists
+		}
+		return false
+	case *typevars.ReturnType:
+		return r.isTypevarEvaluated(d.Function)
+	case *typevars.Argument:
+		return r.isTypevarEvaluated(d.Function)
+	default:
+		panic(fmt.Sprintf("Unrecognized typevar: %#v", i))
+	}
+}
+
+func (r *Runner) splitContracts(ctrs *contractPayload) (*contractPayload, *contractPayload) {
+	// create two groups:
+	// - contracts ready for evaluation
+	// - contracts not ready for evaluation
+
+	readyPayload := newContractPayload(nil)
+	unreadyPayload := newContractPayload(nil)
+
+	for key, cs := range ctrs.contracts() {
+		for _, c := range cs {
+			ready := false
+			switch d := c.(type) {
+			case *contracts.UnaryOp:
+				if r.isTypevarEvaluated(d.X) {
+					ready = true
+				}
+			case *contracts.BinaryOp:
+				if r.isTypevarEvaluated(d.X) && r.isTypevarEvaluated(d.Y) {
+					ready = true
+				}
+			case *contracts.HasField:
+				if r.isTypevarEvaluated(d.X) {
+					ready = true
+				}
+			case *contracts.IsCompatibleWith:
+				if r.isTypevarEvaluated(d.X) && r.isTypevarEvaluated(d.Y) {
+					ready = true
+				}
+			case *contracts.PropagatesTo:
+				if r.isTypevarEvaluated(d.X) {
+					ready = true
+				}
+			case *contracts.IsInvocable:
+				if r.isTypevarEvaluated(d.F) {
+					ready = true
+				}
+			default:
+				panic(fmt.Sprintf("Unrecognized contract: %#v", c))
+			}
+
+			if ready {
+				readyPayload.addContract(key, c)
+			} else {
+				unreadyPayload.addContract(key, c)
+			}
+		}
+	}
+
+	// fmt.Printf("\n\nReady:\n")
+	// readyPayload.dump()
+	// fmt.Printf("\nUnready:\n")
+	// unreadyPayload.dump()
+
+	return readyPayload, unreadyPayload
+}
+
+func (r *Runner) evaluateContract(c contracts.Contract) error {
+	getVar := func(i typevars.Interface) *varTableItem {
+		return r.varTable.GetVariable(i.(*typevars.Variable).String())
+	}
+
+	setVar := func(i typevars.Interface, item *varTableItem) {
+		r.varTable.SetVariable(i.(*typevars.Variable).String(), item)
+	}
+
+	switch d := c.(type) {
+	case *contracts.UnaryOp:
+		xVarItem := getVar(d.X)
+
+		yDataType, err := propagation.New(nil).UnaryExpr(
+			d.OpToken,
+			xVarItem.dataType,
+		)
+		if err != nil {
+			return err
+		}
+
+		setVar(d.Y, &varTableItem{
+			dataType:    yDataType,
+			packageName: xVarItem.packageName,
+			symbolTable: xVarItem.symbolTable,
+		})
+
+		// fmt.Println(contracts.Contract2String(d))
+	case *contracts.BinaryOp:
+		xVarItem := getVar(d.X)
+		yVarItem := getVar(d.Y)
+
+		// have the BinaryExpr return symbol table and the package name as well
+		// it will be either builtin or the current package
+		zDataType, err := propagation.New(nil).BinaryExpr(
+			d.OpToken,
+			xVarItem.dataType,
+			yVarItem.dataType,
+		)
+		if err != nil {
+			return err
+		}
+
+		setVar(d.Z, &varTableItem{
+			dataType:    zDataType,
+			packageName: xVarItem.packageName,
+			symbolTable: xVarItem.symbolTable,
+		})
+
+		// fmt.Println(contracts.Contract2String(d))
+	case *contracts.HasField:
+		xVarItem := getVar(d.X)
+		// fmt.Println(contracts.Contract2String(d))
+
+		if d.Field != "" {
+			yDataType, err := propagation.New(r.symbolAccessor).SelectorExpr(
+				xVarItem.dataType,
+				d.Field,
+			)
+			// fmt.Printf("yDataType: %#v, \terr: %v\n", yDataType, err)
+			if err != nil {
+				return err
+			}
+			r.varTable.SetField(d.X.(*typevars.Variable).String(), d.Field, &varTableItem{
+				dataType: yDataType,
+				// once RetrieveDataTypeField returns the symbol table and the package name, set the two below properly
+				packageName: xVarItem.packageName,
+				symbolTable: xVarItem.symbolTable,
+			})
+		} else {
+			// retrieve positional field
+			panic("retrieve positional field NYI")
+		}
+
+	case *contracts.IsCompatibleWith:
+	//   if r.isTypevarEvaluated(d.X) && r.isTypevarEvaluated(d.Y) {
+	//     ready = true
+	//   }
+	case *contracts.PropagatesTo:
+		// fmt.Printf("PT.X: %#v\n", d.X)
+		// fmt.Printf("PT.Y: %#v\n", d.Y)
+
+		switch td := d.X.(type) {
+		case *typevars.Constant:
+			// The RHS is always a variable
+			st, err := r.globalSymbolTable.Lookup(td.Package)
+			if err != nil {
+				panic(err)
+			}
+			setVar(d.Y, &varTableItem{
+				dataType:    td.DataType,
+				packageName: td.Package,
+				symbolTable: st,
+			})
+		case *typevars.Variable:
+			setVar(d.Y, getVar(d.X))
+		case *typevars.Field:
+			item, _ := r.varTable.GetField(td.X.String(), td.Name)
+			setVar(d.Y, item)
+		case *typevars.ReturnType:
+			// fmt.Printf("d.X: %#v\n", td.Function)
+			item := getVar(td.Function)
+			// fmt.Printf("item: %#v\n", item)
+			switch fDef := item.dataType.(type) {
+			case *gotypes.Method:
+				// fmt.Printf("item(%v): %#v\n", td.Index, fDef.Def.(*gotypes.Function).Results[td.Index])
+				setVar(d.Y, &varTableItem{
+					dataType:    fDef.Def.(*gotypes.Function).Results[td.Index],
+					packageName: item.packageName,
+					symbolTable: item.symbolTable,
+				})
+			case *gotypes.Function:
+				// fmt.Printf("item(%v): %#v\n", td.Index, fDef.Results[td.Index])
+				setVar(d.Y, &varTableItem{
+					dataType:    fDef.Results[td.Index],
+					packageName: item.packageName,
+					symbolTable: item.symbolTable,
+				})
+			default:
+				return fmt.Errorf("d.X of typevars.ReturnType expected to be a funtion/method, got %#v instead", item.dataType)
+			}
+		default:
+			panic(fmt.Sprintf("Unrecognized typevar %#v during PropagatesTo evaluation", d.X))
+		}
+		// fmt.Println(contracts.Contract2String(d))
+	case *contracts.IsInvocable:
+		item := getVar(d.F)
+		// TODO(jchaloup): call getFunctionDef in case the DataType is an identifier
+		// fmt.Printf("d.F: %#v\n", item.dataType)
+		if _, ok := item.dataType.(*gotypes.Method); ok {
+			return nil
+		}
+		if _, ok := item.dataType.(*gotypes.Function); ok {
+			return nil
+		}
+		return fmt.Errorf("d.F of contracts.IsInvocable expected to be a funtion/method, got %#v instead", item.dataType)
+	default:
+		panic(fmt.Sprintf("Unrecognized contract: %#v", c))
+	}
+
+	return nil
+}
+
+func (r *Runner) dumpTypeVars() {
+	fmt.Printf("\n\n")
+	r.varTable.Dump()
+	fmt.Printf("\n\n")
+}
+
+func (r *Runner) Run() error {
+	// propagate data type definitions of all entry typevars
+	// for key, _ := range r.entryTypevars {
+	// 	fmt.Printf("ev: %#v\n", key)
+	// 	// if _, ok := r.varsTypes[key]; !ok {
+	// 	// 	r.varsTypes[key] = nil
+	// 	// 	// st, err := r.globalSymbolTable.Lookup(v.Package)
+	// 	// 	// if err != nil {
+	// 	// 	// 	return err
+	// 	// 	// }
+	// 	// 	// fmt.Printf("ST: %#v\n", st)
+	// 	// }
+	// }
+
+	ready, unready := r.splitContracts(newContractPayload(r.waitingContracts.contracts()))
+	for !ready.isEmpty() {
+		for _, d := range ready.contracts() {
+			for _, c := range d {
+				if err := r.evaluateContract(c); err != nil {
+					return nil
+				}
+			}
+		}
+		ready, unready = r.splitContracts(unready)
+	}
+	// r.dumpTypeVars()
+	return nil
+}
+
+func (r *Runner) VarTable() *varTable {
+	return r.varTable
+}

--- a/pkg/analyzers/type/runner/types.go
+++ b/pkg/analyzers/type/runner/types.go
@@ -1,0 +1,138 @@
+package runner
+
+import (
+	"fmt"
+	"sort"
+
+	"github.com/gofed/symbols-extractor/pkg/parser/contracts"
+	"github.com/gofed/symbols-extractor/pkg/symbols"
+	gotypes "github.com/gofed/symbols-extractor/pkg/types"
+)
+
+type var2Contract struct {
+	vars map[string][]contracts.Contract
+}
+
+func newVar2Contract() *var2Contract {
+	return &var2Contract{
+		vars: make(map[string][]contracts.Contract),
+	}
+}
+
+func (v *var2Contract) addVar(name string, c contracts.Contract) {
+	// Storing virtual variables only => no package scope
+	if _, ok := v.vars[name]; !ok {
+		v.vars[name] = make([]contracts.Contract, 0)
+	}
+	v.vars[name] = append(v.vars[name], c)
+}
+
+type contractPayload struct {
+	items map[string][]contracts.Contract
+}
+
+func newContractPayload(ctrs map[string][]contracts.Contract) *contractPayload {
+	if ctrs == nil {
+		return &contractPayload{
+			items: make(map[string][]contracts.Contract),
+		}
+	}
+	return &contractPayload{
+		items: ctrs,
+	}
+}
+
+func (cp *contractPayload) addContract(funcName string, c contracts.Contract) {
+	if _, ok := cp.items[funcName]; !ok {
+		cp.items[funcName] = make([]contracts.Contract, 0)
+	}
+	cp.items[funcName] = append(cp.items[funcName], c)
+}
+
+func (cp *contractPayload) contracts() map[string][]contracts.Contract {
+	return cp.items
+}
+
+func (cp *contractPayload) isEmpty() bool {
+	return len(cp.items) == 0
+}
+
+func (cp *contractPayload) dump() {
+	for _, d := range cp.items {
+		for _, c := range d {
+			fmt.Printf("  %v\n", contracts.Contract2String(c))
+		}
+	}
+}
+
+/////////////////////////////////////////////////////////////
+// Mapping of variables to its actual data type definition //
+// virtual.var.1: ...
+// virtual.var.1#Field(name): ...
+// virtual.var.1#Field(name): ...
+// virtual.var.1#MapValue: ...
+// virtual.var.1#ListValue: ...
+//
+type varTableItem struct {
+	dataType    gotypes.DataType
+	symbolTable symbols.SymbolLookable
+	packageName string
+}
+
+func (v *varTableItem) DataType() gotypes.DataType {
+	return v.dataType
+}
+
+type varTable struct {
+	// variable name
+	variables map[string]*varTableItem
+	// variable name, field
+	fields map[string]map[string]*varTableItem
+}
+
+func newVarTable() *varTable {
+	return &varTable{
+		variables: make(map[string]*varTableItem),
+		fields:    make(map[string]map[string]*varTableItem),
+	}
+}
+
+func (v *varTable) Names() []string {
+	var names []string
+	for name := range v.variables {
+		names = append(names, name)
+	}
+	return names
+}
+
+func (v *varTable) SetVariable(name string, item *varTableItem) {
+	v.variables[name] = item
+}
+
+func (v *varTable) GetVariable(name string) *varTableItem {
+	// TODO(jchaloup): handle case when the variable does not exist
+	return v.variables[name]
+}
+
+func (v *varTable) SetField(name, field string, item *varTableItem) {
+	if _, ok := v.fields[name]; !ok {
+		v.fields[name] = make(map[string]*varTableItem)
+	}
+	v.fields[name][field] = item
+}
+
+func (v *varTable) GetField(name, field string) (*varTableItem, bool) {
+	item, ok := v.fields[name][field]
+	return item, ok
+}
+
+func (v varTable) Dump() {
+	var keys []string
+	for key := range v.variables {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+	for _, key := range keys {
+		fmt.Printf("varsTable[%v]: %#v\n", key, v.variables[key])
+	}
+}

--- a/tests/integration/typepropagation/basic_test.go
+++ b/tests/integration/typepropagation/basic_test.go
@@ -1,10 +1,13 @@
 package typepropagation
 
 import (
+	"encoding/json"
 	"fmt"
+	"reflect"
 	"testing"
 
 	"github.com/gofed/symbols-extractor/pkg/analyzers/type/runner"
+	gotypes "github.com/gofed/symbols-extractor/pkg/types"
 	cutils "github.com/gofed/symbols-extractor/tests/integration/contracts"
 	"github.com/gofed/symbols-extractor/tests/integration/utils"
 )
@@ -24,7 +27,147 @@ func TestSelfTypePropagation(t *testing.T) {
 		return
 	}
 
-	fmt.Printf("contracts: %#v\n", config.ContractTable.Contracts())
-	fmt.Printf("package: %v\n", config.PackageName)
-	runner.New(config).Run()
+	t.Logf("contracts: %#v\n", config.ContractTable.Contracts())
+	t.Logf("package: %v\n", config.PackageName)
+	r := runner.New(config)
+	if err := r.Run(); err != nil {
+		t.Fatal(err)
+	}
+
+	varTable := r.VarTable()
+	names := varTable.Names()
+
+	expected := []struct {
+		name     string
+		dataType gotypes.DataType
+	}{
+		{
+			name: "#a#:167",
+			dataType: &gotypes.Pointer{
+				Def: &gotypes.Identifier{
+					Def:     "A",
+					Package: "github.com/gofed/symbols-extractor/tests/integration/typepropagation/testdata",
+				},
+			},
+		},
+		{
+			name:     "#x#:180",
+			dataType: &gotypes.Builtin{Def: "int"},
+		},
+		{
+			name:     "#y#:183",
+			dataType: &gotypes.Builtin{Def: "int"},
+		},
+		{
+			name: "github.com/gofed/symbols-extractor/tests/integration/typepropagation/testdata#C#:217",
+			dataType: &gotypes.Pointer{
+				Def: &gotypes.Identifier{
+					Def:     "A",
+					Package: "github.com/gofed/symbols-extractor/tests/integration/typepropagation/testdata",
+				},
+			},
+		},
+		{
+			name: "#a#:243",
+			dataType: &gotypes.Pointer{
+				Def: &gotypes.Identifier{
+					Def:     "A",
+					Package: "github.com/gofed/symbols-extractor/tests/integration/typepropagation/testdata",
+				},
+			},
+		},
+		{
+			name:     "#b#:323",
+			dataType: &gotypes.Builtin{Def: "int"},
+		},
+		// virtual variables
+		{
+			name: "#virtual.var.1#",
+			dataType: &gotypes.Identifier{
+				Def:     "A",
+				Package: "github.com/gofed/symbols-extractor/tests/integration/typepropagation/testdata",
+			},
+		},
+		{
+			name: "#virtual.var.2#",
+			dataType: &gotypes.Pointer{
+				Def: &gotypes.Identifier{
+					Def:     "A",
+					Package: "github.com/gofed/symbols-extractor/tests/integration/typepropagation/testdata",
+				},
+			},
+		},
+		{
+			name:     "#virtual.var.3#",
+			dataType: &gotypes.Builtin{Def: "int"},
+		},
+		{
+			name: "#virtual.var.4#",
+			dataType: &gotypes.Identifier{
+				Def:     "A",
+				Package: "github.com/gofed/symbols-extractor/tests/integration/typepropagation/testdata",
+			},
+		},
+
+		{
+			name: "#virtual.var.5#",
+			dataType: &gotypes.Struct{
+				Fields: []gotypes.StructFieldsItem{
+					{
+						Name: "f",
+						Def:  &gotypes.Builtin{Def: "float32"},
+					},
+				},
+			},
+		},
+		{
+			name: "#virtual.var.6#",
+			dataType: &gotypes.Pointer{
+				Def: &gotypes.Identifier{
+					Def:     "A",
+					Package: "github.com/gofed/symbols-extractor/tests/integration/typepropagation/testdata",
+				},
+			},
+		},
+		{
+			name: "#virtual.var.7#",
+			dataType: &gotypes.Method{
+				Receiver: &gotypes.Pointer{
+					Def: &gotypes.Identifier{
+						Def:     "A",
+						Package: "github.com/gofed/symbols-extractor/tests/integration/typepropagation/testdata",
+					},
+				},
+				Def: &gotypes.Function{
+					Package: "github.com/gofed/symbols-extractor/tests/integration/typepropagation/testdata",
+					Params: []gotypes.DataType{
+						&gotypes.Builtin{Def: "int"},
+						&gotypes.Builtin{Def: "int"},
+					},
+					Results: []gotypes.DataType{
+						&gotypes.Builtin{Def: "int"},
+					},
+				},
+			},
+		},
+	}
+
+	for _, e := range expected {
+		tested := varTable.GetVariable(e.name)
+		fmt.Printf("Checking %q variable...\n", e.name)
+		if !reflect.DeepEqual(tested.DataType(), e.dataType) {
+			tByteSlice, _ := json.Marshal(tested.DataType())
+			eByteSlice, _ := json.Marshal(e.dataType)
+			t.Errorf("Got %v, expected %v", string(tByteSlice), string(eByteSlice))
+		}
+	}
+
+	if len(names) > len(expected) {
+		t.Errorf("There is %v variables not yet checked", len(names)-len(expected))
+	}
+
+	// sort.Strings(names)
+	// for _, name := range names {
+	// 	fmt.Printf("Name: %v\tDataType: %#v\n", name, varTable.GetVariable(name).DataType())
+	// }
 }


### PR DESCRIPTION
Just basically propagadate the same data types as were collected during the AST processing.
This is a heads-up for propagating updated types through all the contracts.