### PR TITLE
Present properly allocated symbols table of a common project

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,11 +36,15 @@ To extract artefacts from a project (assuming the standard Go library is process
 
 ```bash
 ./extract \
-    --project=github.com/coreos/etcd:7a8c192c8f24cbc77e505cabc5153108f59f789c
+    --project=github.com/coreos/etcd:7a8c192c8f24cbc77e505cabc5153108f59f789c \
+    --project-from-dir=<PATH> \
     --stdlib=1.9.1
 ```
 
 If the `--stdlib` option is not set, the latest available processed version is used.
+Both `--project` and `--project-from-dir` options are required.
+
+Currently, all projects (and its dependencies) must be processed before the API check is performed.
 
 #### API Compatibility detection
 

--- a/gen-types.py
+++ b/gen-types.py
@@ -306,6 +306,12 @@ func (o *SymbolDef) UnmarshalJSON(b []byte) error {
         }
         o.Def = r
     {% endfor %}
+    case gotypes.NilType:
+		r := &gotypes.Nil{}
+		if err := json.Unmarshal(*objMap["def"], &r); err != nil {
+			return err
+		}
+		o.Def = r
     }
 
 	return nil

--- a/pkg/parser/alloctable/global/global.go
+++ b/pkg/parser/alloctable/global/global.go
@@ -58,6 +58,35 @@ func (t *Table) Files(packagePath string) []string {
 	return files
 }
 
+// MergeFiles merges all per-file allocated tables into one
+func (t *Table) MergeFiles(packagePath string) (*alloctable.Table, error) {
+	maTable := alloctable.New(packagePath, "")
+	table, ok := t.tables[packagePath]
+	if !ok {
+		return nil, fmt.Errorf("Unable to find %q package", packagePath)
+	}
+	for _, atable := range table {
+		for pkg, symbolSets := range atable.Symbols {
+			for _, item := range symbolSets.Datatypes {
+				maTable.AddDataType(pkg, item.Name, item.Pos)
+			}
+			for _, item := range symbolSets.Functions {
+				maTable.AddFunction(pkg, item.Name, item.Pos)
+			}
+			for _, item := range symbolSets.Variables {
+				maTable.AddVariable(pkg, item.Name, item.Pos)
+			}
+			for _, item := range symbolSets.Methods {
+				maTable.AddMethod(pkg, item.Parent, item.Name, item.Pos)
+			}
+			for _, item := range symbolSets.Structfields {
+				maTable.AddStructField(pkg, item.Parent, item.Field, item.Pos)
+			}
+		}
+	}
+	return maTable, nil
+}
+
 func (t *Table) Lookup(packagePath, file string) (*alloctable.Table, error) {
 	files, ok := t.tables[packagePath]
 	if !ok {

--- a/pkg/parser/contracts/table/table.go
+++ b/pkg/parser/contracts/table/table.go
@@ -188,7 +188,7 @@ func (pc *PackageContracts) UnmarshalJSON(b []byte) error {
 		}
 	}
 
-	pc = &pContracts
+	*pc = pContracts
 
 	return nil
 }

--- a/pkg/parser/contracts/typevars/types.go
+++ b/pkg/parser/contracts/typevars/types.go
@@ -42,10 +42,6 @@ func (c *Constant) GetType() Type {
 }
 
 func (o *Constant) MarshalJSON() (b []byte, e error) {
-
-	if o.DataType == nil {
-		panic(o)
-	}
 	type Copy Constant
 	return json.Marshal(&struct {
 		Type string `json:"type"`
@@ -180,6 +176,12 @@ func UnmarshalDataType(rawMessage *json.RawMessage) (gotypes.DataType, error) {
 		return r, nil
 	case gotypes.StructType:
 		r := &gotypes.Struct{}
+		if err := json.Unmarshal(*rawMessage, &r); err != nil {
+			return nil, err
+		}
+		return r, nil
+	case gotypes.NilType:
+		r := &gotypes.Nil{}
 		if err := json.Unmarshal(*rawMessage, &r); err != nil {
 			return nil, err
 		}

--- a/pkg/symbols/symbol.go
+++ b/pkg/symbols/symbol.go
@@ -150,6 +150,12 @@ func (o *SymbolDef) UnmarshalJSON(b []byte) error {
 		}
 		o.Def = r
 
+	case gotypes.NilType:
+		r := &gotypes.Nil{}
+		if err := json.Unmarshal(*objMap["def"], &r); err != nil {
+			return err
+		}
+		o.Def = r
 	}
 
 	return nil

--- a/pkg/types/internal_types.go
+++ b/pkg/types/internal_types.go
@@ -1,5 +1,7 @@
 package types
 
+import "encoding/json"
+
 const NilType = "nil"
 
 type Nil struct {
@@ -7,6 +9,27 @@ type Nil struct {
 
 func (n *Nil) GetType() string {
 	return NilType
+}
+
+func (o *Nil) MarshalJSON() (b []byte, e error) {
+	type Copy Nil
+	return json.Marshal(&struct {
+		Type string `json:"type"`
+		*Copy
+	}{
+		Type: NilType,
+		Copy: (*Copy)(o),
+	})
+}
+
+func (o *Nil) UnmarshalJSON(b []byte) error {
+	var objMap map[string]*json.RawMessage
+
+	if err := json.Unmarshal(b, &objMap); err != nil {
+		return err
+	}
+
+	return nil
 }
 
 // BuiltinLiteralType is a type constant for built-in literal

--- a/tests/integration/contracts/utils.go
+++ b/tests/integration/contracts/utils.go
@@ -179,7 +179,7 @@ func ParseAndCompareVarTable(t *testing.T, gopkg, filename string, expected []Va
 		return
 	}
 
-	r := runner.New(config, allocglobal.New("", ""))
+	r := runner.New(config.PackageName, config.GlobalSymbolTable, allocglobal.New("", ""), config.ContractTable)
 	if err := r.Run(); err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
Features:
- display allocated symbols per file/per package
- display allocated symbols of exported symbols
- display allocated symbols table in json for further processing

Minor fixes:
- parse Nil properly
- extract dynamic allocation from generated artefacts
- store the unmarshalled contract table properly