### PR TITLE
Extract common project with a glide.lock file

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -112,7 +112,7 @@ goenv:
 
 build:
 	$(RMLOG)
-	$(GO_BUILD) $(GO_BUILD_FLAGS) -o extract $(PROJECT_ROOT)/cmd $(WLOG)
+	$(GO_BUILD) $(GO_BUILD_FLAGS) -o extract $(PROJECT_ROOT)/cmd/extract $(WLOG)
 
 test:
 	@ $(RMLOG)

--- a/pkg/parser/file/parser_test.go
+++ b/pkg/parser/file/parser_test.go
@@ -59,7 +59,7 @@ func TestDataTypes(t *testing.T) {
 		t.Fatalf("AST Parse error: %v", err)
 	}
 
-	gtable := global.New("", "")
+	gtable := global.New("", "", nil)
 
 	config := &parsertypes.Config{
 		PackageName:           "builtin",

--- a/pkg/parser/statement/parser_test.go
+++ b/pkg/parser/statement/parser_test.go
@@ -23,7 +23,7 @@ func prepareParser(pkgName string) *types.Config {
 		PackageName:           pkgName,
 		SymbolTable:           stack.New(),
 		AllocatedSymbolsTable: alloctable.New("", ""),
-		GlobalSymbolTable:     global.New("", ""),
+		GlobalSymbolTable:     global.New("", "", nil),
 	}
 	c.SymbolsAccessor = accessors.NewAccessor(c.GlobalSymbolTable).SetCurrentTable(c.PackageName, c.SymbolTable)
 

--- a/pkg/snapshots/glide/glide.go
+++ b/pkg/snapshots/glide/glide.go
@@ -1,0 +1,60 @@
+package glide
+
+import (
+	"fmt"
+	"io/ioutil"
+	"strings"
+
+	yaml "gopkg.in/yaml.v2"
+)
+
+type GlideImport struct {
+	Name    string `json:"name"`
+	Version string `json:"version"`
+}
+
+type Glide struct {
+	Hash        string        `json:"hash"`
+	Updated     string        `json:"updated"`
+	Imports     []GlideImport `json:"imports"`
+	TestImports []GlideImport `json:"testImports"`
+
+	importsList   map[string]string
+	mainPkg       string
+	mainPkgCommit string
+}
+
+func GlideFromFile(file string) (*Glide, error) {
+	yamlFile, err := ioutil.ReadFile(file)
+	if err != nil {
+		return nil, fmt.Errorf("Unable to load file %v: %v", file, err)
+	}
+
+	var glide Glide
+	err = yaml.Unmarshal(yamlFile, &glide)
+	if err != nil {
+		panic(err)
+	}
+
+	glide.importsList = make(map[string]string)
+	for _, item := range glide.Imports {
+		glide.importsList[item.Name] = item.Version
+	}
+
+	return &glide, nil
+}
+
+func (g *Glide) Commit(pkg string) (string, error) {
+	if g.mainPkg != "" && g.mainPkgCommit != "" && strings.HasPrefix(pkg, g.mainPkg) {
+		return g.mainPkgCommit, nil
+	}
+	if commit, ok := g.importsList[pkg]; ok {
+		return commit, nil
+	}
+	return "", fmt.Errorf("Commit for package %q not found", pkg)
+}
+
+func (g *Glide) MainPackageCommit(pkg string, commit string) {
+	g.mainPkg = pkg
+	g.mainPkgCommit = commit
+}

--- a/pkg/snapshots/types.go
+++ b/pkg/snapshots/types.go
@@ -1,0 +1,5 @@
+package snapshots
+
+type Snapshot interface {
+	Commit(pkg string) (string, error)
+}

--- a/tests/integration/contracts/utils.go
+++ b/tests/integration/contracts/utils.go
@@ -179,7 +179,7 @@ func ParseAndCompareVarTable(t *testing.T, gopkg, filename string, expected []Va
 		return
 	}
 
-	r := runner.New(config.PackageName, config.GlobalSymbolTable, allocglobal.New("", ""), config.ContractTable)
+	r := runner.New(config.PackageName, config.GlobalSymbolTable, allocglobal.New("", "", nil), config.ContractTable)
 	if err := r.Run(); err != nil {
 		t.Fatal(err)
 	}

--- a/tests/integration/utils/utils.go
+++ b/tests/integration/utils/utils.go
@@ -56,7 +56,7 @@ func parseBuiltin(config *parsertypes.Config) error {
 }
 
 func InitFileParser(gopkg string) (*fileparser.FileParser, *types.Config, error) {
-	gtable := global.New("", "")
+	gtable := global.New("", "", nil)
 
 	config := &parsertypes.Config{
 		PackageName:           "builtin",


### PR DESCRIPTION
So we can generated a package with its corresponding commit:
```sh
generated/github.com/
└── kr
    ├── pretty
    │   └── cfb55aafdaf3ec08f0db22699ab822c50091b1c4
    │       ├── allocated.json
    │       ├── api.json
    │       └── contracts.json
    └── text
        └── 7cafcd837844e784b526369c9bce262804aebc60
            ├── allocated.json
            ├── api.json
            └── contracts.json
```
