### PR TITLE
Report API changes in allocated symbols

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
-generated
+/generated
+/extract
+/checkapi

--- a/Makefile
+++ b/Makefile
@@ -113,6 +113,7 @@ goenv:
 build:
 	$(RMLOG)
 	$(GO_BUILD) $(GO_BUILD_FLAGS) -o extract $(PROJECT_ROOT)/cmd/extract $(WLOG)
+	$(GO_BUILD) $(GO_BUILD_FLAGS) -o checkapi $(PROJECT_ROOT)/cmd/checkapi $(WLOG)
 
 test:
 	@ $(RMLOG)
@@ -156,4 +157,4 @@ scan:
 	./extract --stdlib --symbol-table-dir generated --cgo-symbols-path cgo/cgo.yml
 
 clean:
-	rm -rf extract symboltables generated
+	rm -rf extract checkapi generated

--- a/cgo/cgo.yml
+++ b/cgo/cgo.yml
@@ -60,6 +60,9 @@ variables:
 - name: PATH_MAX
   type:
     constant: int
+- name: RTLD_LAZY
+  type:
+    constant: int
 # no need to know definition of the data type, just its name
 types:
 - name: struct_sockaddr
@@ -77,6 +80,8 @@ types:
 - name: struct_addrinfo
   type:
     struct:
+    - name: ai_flags
+      identifier: C.int
     - name: ai_socktype
       identifier: C.int
     - name: ai_protocol
@@ -259,3 +264,71 @@ functions:
   result:
   - pointer:
       identifier: C.void
+- name: dlerror
+  result:
+  - pointer:
+      identifier: C.char
+- name: dlopen
+  params:
+  - pointer:
+      identifier: C.char
+  - identifier: C.int
+  result:
+  - pointer:
+      identifier: C.void
+- name: dlclose
+  params:
+  - pointer:
+      identifier: C.void
+  result:
+  - identifier: C.int
+- name: dlsym
+  params:
+  - pointer:
+      identifier: C.void
+  - pointer:
+      identifier: C.char
+  result:
+  - pointer:
+      identifier: C.void
+- name: my_strlen
+  params:
+  - pointer:
+      identifier: C.void
+  - pointer:
+      identifier: C.char
+  result:
+  - identifier: C.int
+- name: my_sd_pid_get_owner_uid
+  params:
+  - pointer:
+      identifier: C.void
+    identifier: C.pid_t
+  - pointer:
+      identifier: C.uid_t
+  result:
+  - identifier: C.int
+- name: my_sd_pid_get_unit
+  params:
+  - pointer:
+      identifier: C.void
+    identifier: C.pid_t
+  - pointer:
+      pointer:
+        identifier: C.unit
+  result:
+  - identifier: C.int
+- name: my_sd_pid_get_slice
+  params:
+  - pointer:
+      identifier: C.void
+    identifier: C.pid_t
+  - pointer:
+      pointer:
+        identifier: C.char
+  result:
+  - identifier: C.int
+- name: am_session_leader
+  result:
+  - identifier: C.int
+

--- a/cmd/checkapi/checkapi.go
+++ b/cmd/checkapi/checkapi.go
@@ -1,0 +1,560 @@
+package main
+
+import (
+	"encoding/json"
+	"flag"
+	"fmt"
+	"go/ast"
+	"io/ioutil"
+	"path"
+	"reflect"
+	"runtime"
+	"strings"
+
+	allocglobal "github.com/gofed/symbols-extractor/pkg/parser/alloctable/global"
+	"github.com/gofed/symbols-extractor/pkg/snapshots"
+	"github.com/gofed/symbols-extractor/pkg/snapshots/glide"
+	"github.com/gofed/symbols-extractor/pkg/snapshots/godeps"
+	"github.com/gofed/symbols-extractor/pkg/symbols/accessors"
+	"github.com/gofed/symbols-extractor/pkg/symbols/tables/global"
+
+	"github.com/golang/glog"
+)
+
+//////////
+// checkapi --allocated <ALLOCATED>.json --package-path <EXERCISED_DEPENDENCY> --symbol-table-dir <PACKAGE_APIS> --cgo-symbols-path <CGO>
+//
+// The --symbol-table-dir is a `:` separated list of paths with generated directory
+//
+// E.g.
+// checkapi --alocated toml.json --package-path github.com/coreos/etcd:commit --symbol-table-dir generated:updates/1.10/generated
+//
+
+type flags struct {
+	allocated           *string
+	allocatedGlidefile  *string
+	allocatedGodepsfile *string
+	packagePrefix       *string
+	packageCommit       *string
+	symbolTablePath     *string
+	cgoSymbolsPath      *string
+	goVersion           *string
+	glidefile           *string
+	godepsfile          *string
+}
+
+func (f *flags) parse() error {
+	flag.Parse()
+
+	if *(f.allocated) == "" {
+		return fmt.Errorf("--allocated is not set")
+	}
+
+	if *(f.packagePrefix) == "" {
+		return fmt.Errorf("--package-prefix is not set")
+	}
+
+	if *(f.packageCommit) == "" {
+		return fmt.Errorf("--package-commit is not set")
+	}
+
+	if *(f.symbolTablePath) == "" {
+		return fmt.Errorf("--symbol-table-dir is not set")
+	}
+
+	if *(f.goVersion) == "" {
+		return fmt.Errorf("--go-version is not set")
+	}
+
+	if *(f.glidefile) == "" && *f.godepsfile == "" {
+		return fmt.Errorf("-glidefile or -godepsfile is not set")
+	}
+
+	return nil
+}
+
+func initRefGlobaST(f *flags) (*global.Table, snapshots.Snapshot, error) {
+	if *f.allocatedGlidefile != "" {
+		snapshot, err := glide.GlideFromFile(*f.allocatedGlidefile)
+		if err != nil {
+			return nil, nil, err
+		}
+		return global.New(*(f.symbolTablePath), *(f.goVersion), snapshot), snapshot, nil
+	} else if *f.allocatedGodepsfile != "" {
+		snapshot, err := godeps.FromFile(*f.allocatedGodepsfile)
+		if err != nil {
+			return nil, nil, err
+		}
+		return global.New(*(f.symbolTablePath), *(f.goVersion), snapshot), snapshot, nil
+	}
+	return global.New(*(f.symbolTablePath), *(f.goVersion), nil), nil, nil
+}
+
+func initExercisedGlobaST(f *flags) (*global.Table, snapshots.Snapshot, error) {
+	if *f.glidefile != "" {
+		snapshot, err := glide.GlideFromFile(*f.glidefile)
+		if err != nil {
+			return nil, nil, err
+		}
+		snapshot.MainPackageCommit(*f.packagePrefix, *f.packageCommit)
+		return global.New(*(f.symbolTablePath), *(f.goVersion), snapshot), snapshot, nil
+	}
+	snapshot, err := godeps.FromFile(*f.godepsfile)
+	if err != nil {
+		return nil, nil, err
+	}
+	snapshot.MainPackageCommit(*f.packagePrefix, *f.packageCommit)
+	return global.New(*(f.symbolTablePath), *(f.goVersion), snapshot), snapshot, nil
+}
+
+type Triplet struct {
+	Parent, Name string
+	Pos          []string
+}
+
+type Duplet struct {
+	Name string
+	Pos  []string
+}
+
+type ApiDiff struct {
+	DatatypesMissing    []Duplet
+	Datatypes           []Duplet
+	FunctionsMissing    []Duplet
+	Functions           []Duplet
+	VariablesMissing    []Duplet
+	Variables           []Duplet
+	MethodsMissing      []Triplet
+	Methods             []Triplet
+	StructFieldsMissing []Triplet
+	StructFields        []Triplet
+}
+
+func collectApiDiffs(tables map[string]allocglobal.PackageTable, packagePrefix string, refGlobalST, exercisedGlobalST *global.Table) (*ApiDiff, error) {
+	apidiff := ApiDiff{}
+
+	refSTable, err := refGlobalST.Lookup(packagePrefix)
+	if err != nil {
+		return nil, err
+	}
+
+	exerSTable, err := exercisedGlobalST.Lookup(packagePrefix)
+	if err != nil {
+		return nil, err
+	}
+
+	refAccessor := accessors.NewAccessor(refGlobalST)
+	exerAccessor := accessors.NewAccessor(exercisedGlobalST)
+
+	dtNames := make(map[string][]string, 0)
+	fncNames := make(map[string][]string, 0)
+	varNames := make(map[string][]string, 0)
+	fieldNames := make(map[struct{ parent, field string }][]string, 0)
+	methodNames := make(map[struct{ parent, name string }][]string, 0)
+
+	for tablePkg, table := range tables {
+		for file, fileItem := range table {
+			glog.V(1).Infof("Processing %q of %q\n", file, tablePkg)
+			for pkg, symbolsSet := range fileItem.Symbols {
+				// skip anonymous symbols
+				if pkg == "" {
+					continue
+				}
+
+				if pkg != packagePrefix {
+					continue
+				}
+
+				glog.V(1).Infof("Processing %q\n", pkg)
+
+				// Just collect names without positions
+				// Datatypes
+				for _, item := range symbolsSet.Datatypes {
+					if _, ok := dtNames[item.Name]; ok {
+						dtNames[item.Name] = append(dtNames[item.Name], path.Join(fileItem.Package, item.Pos))
+						continue
+					}
+					if !ast.IsExported(item.Name) {
+						continue
+					}
+					dtNames[item.Name] = []string{path.Join(fileItem.Package, item.Pos)}
+				}
+				// Functions
+				for _, item := range symbolsSet.Functions {
+					if _, ok := fncNames[item.Name]; ok {
+						fncNames[item.Name] = append(fncNames[item.Name], path.Join(fileItem.Package, item.Pos))
+						continue
+					}
+					if !ast.IsExported(item.Name) {
+						continue
+					}
+					fncNames[item.Name] = []string{path.Join(fileItem.Package, item.Pos)}
+				}
+				// Variables
+				for _, item := range symbolsSet.Variables {
+					if _, ok := varNames[item.Name]; ok {
+						varNames[item.Name] = append(varNames[item.Name], path.Join(fileItem.Package, item.Pos))
+						continue
+					}
+					if !ast.IsExported(item.Name) {
+						continue
+					}
+					varNames[item.Name] = []string{path.Join(fileItem.Package, item.Pos)}
+				}
+				// Struct fields
+				for _, item := range symbolsSet.Structfields {
+					key := struct{ parent, field string }{item.Parent, item.Field}
+					if _, ok := fieldNames[key]; ok {
+						fieldNames[key] = append(fieldNames[key], path.Join(fileItem.Package, item.Pos))
+						continue
+					}
+					if !ast.IsExported(item.Parent) {
+						continue
+					}
+					if !ast.IsExported(item.Field) {
+						continue
+					}
+					fieldNames[key] = []string{path.Join(fileItem.Package, item.Pos)}
+				}
+				// Methods
+				for _, item := range symbolsSet.Methods {
+					key := struct{ parent, name string }{item.Parent, item.Name}
+					if _, ok := methodNames[key]; ok {
+						methodNames[key] = append(methodNames[key], path.Join(fileItem.Package, item.Pos))
+						continue
+					}
+					if !ast.IsExported(item.Parent) {
+						continue
+					}
+					if !ast.IsExported(item.Name) {
+						continue
+					}
+					methodNames[key] = []string{path.Join(fileItem.Package, item.Pos)}
+				}
+			}
+		}
+	}
+
+	for name := range dtNames {
+		glog.V(1).Infof("Checking %q type", name)
+		refSDef, err := refSTable.LookupDataType(name)
+		if err != nil {
+			return nil, fmt.Errorf("Type %q of %q package not found", name, packagePrefix)
+		}
+
+		exerSDef, err := exerSTable.LookupDataType(name)
+		if err != nil {
+			apidiff.DatatypesMissing = append(apidiff.DatatypesMissing, Duplet{
+				Name: name,
+				Pos:  dtNames[name],
+			})
+			continue
+		}
+
+		// Compare both symbols
+		if !reflect.DeepEqual(refSDef.Def, exerSDef.Def) {
+			apidiff.Datatypes = append(apidiff.Datatypes, Duplet{
+				Name: name,
+				Pos:  dtNames[name],
+			})
+		}
+	}
+
+	for name := range fncNames {
+		glog.V(1).Infof("Checking %q function", name)
+		refSDef, err := refSTable.LookupFunction(name)
+		if err != nil {
+			return nil, fmt.Errorf("Function %q of %q package not found", name, packagePrefix)
+		}
+
+		exerSDef, err := exerSTable.LookupFunction(name)
+		if err != nil {
+			apidiff.FunctionsMissing = append(apidiff.FunctionsMissing, Duplet{
+				Name: name,
+				Pos:  fncNames[name],
+			})
+			continue
+		}
+
+		// Compare both symbols
+		if !reflect.DeepEqual(refSDef.Def, exerSDef.Def) {
+			apidiff.Functions = append(apidiff.Functions, Duplet{
+				Name: name,
+				Pos:  fncNames[name],
+			})
+		}
+	}
+
+	for name := range varNames {
+		glog.V(1).Infof("Checking %q variable", name)
+		refSDef, err := refSTable.LookupVariable(name)
+		if err != nil {
+			return nil, fmt.Errorf("Variable %q of %q package not found", name, packagePrefix)
+		}
+
+		exerSDef, err := exerSTable.LookupVariable(name)
+		if err != nil {
+			apidiff.VariablesMissing = append(apidiff.VariablesMissing, Duplet{
+				Name: name,
+				Pos:  varNames[name],
+			})
+			continue
+		}
+
+		// Compare both symbols
+		if !reflect.DeepEqual(refSDef.Def, exerSDef.Def) {
+			apidiff.Variables = append(apidiff.Variables, Duplet{
+				Name: name,
+				Pos:  varNames[name],
+			})
+		}
+	}
+
+	for item := range methodNames {
+		glog.V(1).Infof("Checking %q method", fmt.Sprintf("%v.%v", item.parent, item.name))
+
+		refSDef, err := refSTable.LookupDataType(item.parent)
+		if err != nil {
+			return nil, fmt.Errorf("Type %q of %q package not found", item.parent, packagePrefix)
+		}
+
+		refMethodDef, err := refAccessor.RetrieveDataTypeField(
+			accessors.NewFieldAccessor(refSTable, refSDef, &ast.Ident{Name: item.name}),
+		)
+		if err != nil {
+			return nil, fmt.Errorf("Method %q of %q Type in %q package not found", item.name, item.parent, packagePrefix)
+		}
+
+		exerSDef, err := exerSTable.LookupDataType(item.parent)
+		if err != nil {
+			apidiff.MethodsMissing = append(apidiff.MethodsMissing, Triplet{
+				Parent: item.parent,
+				Name:   item.name,
+				Pos:    methodNames[item],
+			})
+			continue
+		}
+
+		exerMethodDef, err := exerAccessor.RetrieveDataTypeField(
+			accessors.NewFieldAccessor(exerSTable, exerSDef, &ast.Ident{Name: item.name}),
+		)
+		if err != nil {
+			apidiff.MethodsMissing = append(apidiff.MethodsMissing, Triplet{
+				Parent: item.parent,
+				Name:   item.name,
+				Pos:    methodNames[item],
+			})
+			continue
+		}
+
+		// Compare both symbols
+		if !reflect.DeepEqual(refMethodDef.DataType, exerMethodDef.DataType) {
+			apidiff.Methods = append(apidiff.Methods, Triplet{
+				Parent: item.parent,
+				Name:   item.name,
+				Pos:    methodNames[item],
+			})
+		}
+	}
+
+	for item := range fieldNames {
+		glog.V(1).Infof("Checking %q field", fmt.Sprintf("%v.%v", item.parent, item.field))
+
+		refSDef, err := refSTable.LookupDataType(item.parent)
+		if err != nil {
+			return nil, fmt.Errorf("Type %q of %q package not found", item.parent, packagePrefix)
+		}
+
+		refFieldDef, err := refAccessor.RetrieveDataTypeField(
+			accessors.NewFieldAccessor(refSTable, refSDef, &ast.Ident{Name: item.field}),
+		)
+		if err != nil {
+			return nil, fmt.Errorf("Field %q of %q Type in %q package not found", item.field, item.parent, packagePrefix)
+		}
+
+		exerSDef, err := exerSTable.LookupDataType(item.parent)
+		if err != nil {
+			apidiff.StructFieldsMissing = append(apidiff.StructFieldsMissing, Triplet{
+				Parent: item.parent,
+				Name:   item.field,
+				Pos:    fieldNames[item],
+			})
+			continue
+		}
+
+		exerFieldDef, err := exerAccessor.RetrieveDataTypeField(
+			accessors.NewFieldAccessor(exerSTable, exerSDef, &ast.Ident{Name: item.field}),
+		)
+
+		if err != nil {
+			apidiff.StructFieldsMissing = append(apidiff.StructFieldsMissing, Triplet{
+				Parent: item.parent,
+				Name:   item.field,
+				Pos:    fieldNames[item],
+			})
+			continue
+		}
+
+		// Compare both symbols
+		if !reflect.DeepEqual(refFieldDef.DataType, exerFieldDef.DataType) {
+			apidiff.StructFields = append(apidiff.StructFields, Triplet{
+				Parent: item.parent,
+				Name:   item.field,
+				Pos:    fieldNames[item],
+			})
+		}
+	}
+
+	return &apidiff, nil
+}
+
+const CLR_B = "\x1b[34;1m"
+const CLR_N = "\x1b[0m"
+const CLR_R = "\x1b[31;1m"
+
+func main() {
+
+	f := &flags{
+		allocated:           flag.String("allocated", "", "Allocated symbol table"),
+		allocatedGlidefile:  flag.String("allocated-glidefile", "", "Glide.lock with dependencies of allocated symbol table"),
+		allocatedGodepsfile: flag.String("allocated-godepsfile", "", "Godeps.json with dependencies of allocated symbol table"),
+		packagePrefix:       flag.String("package-prefix", "", "Package entry point"),
+		packageCommit:       flag.String("package-commit", "", "Package commit entry point"),
+		goVersion:           flag.String("go-version", "", "Go stdlib version"),
+		symbolTablePath:     flag.String("symbol-table-dir", "", "Directory with preprocessed symbol tables"),
+		cgoSymbolsPath:      flag.String("cgo-symbols-path", "", "Symbol table with CGO symbols (per entire project space)"),
+		glidefile:           flag.String("glidefile", "", "Glide.lock with dependencies"),
+		godepsfile:          flag.String("godepsfile", "", "Godeps.json with dependencies"),
+	}
+
+	if err := f.parse(); err != nil {
+		glog.Fatal(err)
+	}
+
+	// Otherwise it can eat all the CPU power
+	runtime.GOMAXPROCS(1)
+
+	refGlobalST, refSnapshot, err := initRefGlobaST(f)
+	if err != nil {
+		panic(err)
+	}
+
+	exercisedGlobalST, exercisedSnapshot, err := initExercisedGlobaST(f)
+	if err != nil {
+		panic(err)
+	}
+
+	// TODO(jchaloup): construct the snapshot for the refGlobalST from the allocated table
+
+	// 1. Load the allocated symbols Table
+	var tables map[string]allocglobal.PackageTable
+	raw, err := ioutil.ReadFile(*(f.allocated))
+	if err != nil {
+		panic(err)
+	}
+
+	if err := json.Unmarshal(raw, &tables); err != nil {
+		panic(err)
+	}
+
+	// Global symbols Accessing
+	// - the symbols from the allocated list are accessed through one global symbols table
+	// - the exercised API (and its dependencies) are accessed through another global symbols table
+	//
+
+	// 2. Find each symbol in a global symbol table
+
+	// 3. Compare if the symbol definition is the same as in the allocated
+	apidiff, err := collectApiDiffs(tables, *f.packagePrefix, refGlobalST, exercisedGlobalST)
+	if err != nil {
+		panic(err)
+	}
+
+	pkg := *f.packagePrefix
+	refCommit, _ := refSnapshot.Commit(pkg)
+	exercisedCommit, _ := exercisedSnapshot.Commit(pkg)
+
+	fmt.Printf("Comparing %v:%v with %v:%v\n", pkg, refCommit, pkg, exercisedCommit)
+
+	// 4. Report differences (if there are any)
+	for _, item := range apidiff.Datatypes {
+		// refSTable, _ := refGlobalST.Lookup(pkg)
+		// exerSTable, _ := exercisedGlobalST.Lookup(pkg)
+		// refSDef, _ := refSTable.LookupDataType(item.Name)
+		// exerSDef, _ := exerSTable.LookupDataType(item.Name)
+		//
+		// // structs?
+		// if refSDef.Def.GetType() == gotypes.StructType && exerSDef.Def.GetType() == gotypes.StructType {
+		// 	refFields := make(map[string]gotypes.DataType)
+		// 	exerFields := make(map[string]gotypes.DataType)
+		// 	for _, item := range refSDef.Def.(*gotypes.Struct).Fields {
+		// 		if item.Name == "" {
+		// 			panic("JJJJ")
+		// 		}
+		// 		if !ast.IsExported(item.Name) {
+		// 			continue
+		// 		}
+		// 		refFields[item.Name] = item.Def
+		// 	}
+		//
+		// 	for _, item := range exerSDef.Def.(*gotypes.Struct).Fields {
+		// 		if item.Name == "" {
+		// 			panic("JJJJ")
+		// 		}
+		// 		if !ast.IsExported(item.Name) {
+		// 			continue
+		// 		}
+		// 		exerFields[item.Name] = item.Def
+		// 	}
+		//
+		// 	// any missing fields?
+		// 	for field := range refFields {
+		// 		if _, ok := exerFields[field]; ok {
+		// 			if !reflect.DeepEqual(refFields[field], exerFields[field]) {
+		// 				fmt.Printf("?field %v.%v definition changed\n", item.Name, field)
+		// 			}
+		// 		}
+		// 	}
+		// 	continue
+		// }
+
+		fmt.Printf("%v?type %q changed%v\n\tused at %v\n", CLR_B, item.Name, CLR_N, strings.Join(item.Pos, "\n\tused at "))
+	}
+
+	for _, item := range apidiff.DatatypesMissing {
+		fmt.Printf("%v-type %q missing%v\n\tused at %v\n", CLR_R, item.Name, CLR_N, strings.Join(item.Pos, "\n\tused at "))
+	}
+
+	for _, item := range apidiff.VariablesMissing {
+		fmt.Printf("%v-function %q missing%v\n\tused at %v\n", CLR_R, item.Name, CLR_N, strings.Join(item.Pos, "\n\tused at "))
+	}
+
+	for _, item := range apidiff.Variables {
+		fmt.Printf("%v?function %q changed%v\n\tused at %v\n", CLR_B, item.Name, CLR_N, strings.Join(item.Pos, "\n\tused at "))
+	}
+
+	for _, item := range apidiff.FunctionsMissing {
+		fmt.Printf("%v-function %q missing%v\n\tused at %v\n", CLR_R, item.Name, CLR_N, strings.Join(item.Pos, "\n\tused at "))
+	}
+
+	for _, item := range apidiff.Functions {
+		fmt.Printf("%v?function %q changed%v\n\tused at %v\n", CLR_B, item.Name, CLR_N, strings.Join(item.Pos, "\n\tused at "))
+	}
+
+	for _, item := range apidiff.StructFieldsMissing {
+		fmt.Printf("%v-field %q missing%v\n\tused at %v\n", CLR_R, fmt.Sprintf("%v.%v", item.Parent, item.Name), CLR_N, strings.Join(item.Pos, "\n\tused at "))
+	}
+
+	for _, item := range apidiff.StructFields {
+		fmt.Printf("%v?field %q changed%v\n\tused at %v\n", CLR_B, fmt.Sprintf("%v.%v", item.Parent, item.Name), CLR_N, strings.Join(item.Pos, "\n\tused at "))
+	}
+
+	for _, item := range apidiff.MethodsMissing {
+		fmt.Printf("%v-method %q missing%v\n\tused at %v\n", CLR_R, fmt.Sprintf("%v.%v", item.Parent, item.Name), CLR_N, strings.Join(item.Pos, "\n\tused at "))
+	}
+
+	for _, item := range apidiff.Methods {
+		fmt.Printf("%v?method %q changed%v\n\tused at %v\n", CLR_B, fmt.Sprintf("%v.%v", item.Parent, item.Name), CLR_N, strings.Join(item.Pos, "\n\tused at "))
+	}
+
+}

--- a/cmd/extract/extract.go
+++ b/cmd/extract/extract.go
@@ -30,6 +30,7 @@ type flags struct {
 	stdlib        *bool
 	allocated     *bool
 	recursiveFrom *string
+	filterPrefix  *string
 	perfile       *bool
 	allallocated  *bool
 	tojson        *bool
@@ -100,7 +101,9 @@ func printPackageAllocTables(allocTable *allocglobal.Table, globalTable *global.
 			if err != nil {
 				return err
 			}
-			packageAllocTables[p] = tt
+			if !tt.FilterOut("github.com/coreos/etcd") {
+				packageAllocTables[p] = tt
+			}
 		}
 	} else {
 		if perfile {
@@ -205,6 +208,7 @@ func main() {
 		stdlib:         flag.Bool("stdlib", false, "Parse system Go std library"),
 		allocated:      flag.Bool("allocated", false, "Extract allocation of symbols"),
 		recursiveFrom:  flag.String("recursive-from", "", "Extract allocation of symbols from all prefixed paths"),
+		filterPrefix:   flag.String("filter-prefix", "", "Filter out all imported packages from allocated symbols that does not match the prefix"),
 		perfile:        flag.Bool("per-file", false, "Display allocated symbols per file"),
 		allallocated:   flag.Bool("all-allocated", false, "Display all allocated symbols"),
 		tojson:         flag.Bool("json", false, "Display allocated symbols in JSON"),

--- a/pkg/analyzers/type/runner/types.go
+++ b/pkg/analyzers/type/runner/types.go
@@ -75,8 +75,7 @@ func (cp *contractPayload) isEmpty() bool {
 
 func (cp *contractPayload) len() int {
 	size := 0
-	for key, d := range cp.items {
-		fmt.Printf("key: %v\n", key)
+	for _, d := range cp.items {
 		size += len(d)
 	}
 

--- a/pkg/parser/alloctable/global/global.go
+++ b/pkg/parser/alloctable/global/global.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"path"
 	"sort"
+	"strings"
 
 	"github.com/gofed/symbols-extractor/pkg/parser/alloctable"
 	"github.com/gofed/symbols-extractor/pkg/snapshots"
@@ -212,6 +213,26 @@ func (t *PackageTable) Load(file string) error {
 
 	*t = table
 	return nil
+}
+
+func (t *PackageTable) FilterOut(prefix string) bool {
+	emptyTable := true
+	for file, tab := range *t {
+		empty := true
+		for pkg := range tab.Symbols {
+			if !strings.HasPrefix(pkg, prefix) {
+				delete(tab.Symbols, pkg)
+				continue
+			}
+			empty = false
+		}
+		if empty {
+			delete(*t, file)
+			continue
+		}
+		emptyTable = false
+	}
+	return emptyTable
 }
 
 func (t *Table) loadFromFile(pkg string) (PackageTable, error) {

--- a/pkg/parser/type/type_parser.go
+++ b/pkg/parser/type/type_parser.go
@@ -360,6 +360,11 @@ func (p *Parser) parseFunction(typedExpr *ast.FuncType) (*gotypes.Function, erro
 	return functionType, nil
 }
 
+func (p *Parser) parseParen(typedExpr *ast.ParenExpr) (gotypes.DataType, error) {
+	glog.V(2).Infof("Processing ParentExpr: %#v\n", typedExpr)
+	return p.Parse(typedExpr.X)
+}
+
 func (p *Parser) Parse(expr ast.Expr) (gotypes.DataType, error) {
 	switch typedExpr := expr.(type) {
 	case *ast.Ident:
@@ -382,6 +387,8 @@ func (p *Parser) Parse(expr ast.Expr) (gotypes.DataType, error) {
 		return p.parseInterface(typedExpr)
 	case *ast.FuncType:
 		return p.parseFunction(typedExpr)
+	case *ast.ParenExpr:
+		return p.parseParen(typedExpr)
 	}
 	return nil, fmt.Errorf("ast.Expr (%#v) not recognized when parsing a type definition", expr)
 }

--- a/pkg/symbols/accessors/accessors.go
+++ b/pkg/symbols/accessors/accessors.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"go/ast"
+	"strings"
 
 	"github.com/gofed/symbols-extractor/pkg/symbols"
 	"github.com/gofed/symbols-extractor/pkg/symbols/tables/global"
@@ -939,9 +940,19 @@ ITEMS_LOOP:
 			}
 			switch fieldType := itemExpr.(type) {
 			case *gotypes.Identifier:
-				if !accessor.methodsOnly && fieldType.Def == accessor.field.String() {
-					fieldItem = &item
-					break ITEMS_LOOP
+				if !accessor.methodsOnly {
+					var fieldName string
+					// localy defined data type?
+					if parts := strings.Split(fieldType.Def, "#"); len(parts) == 3 {
+						fieldName = parts[2]
+					} else {
+						fieldName = fieldType.Def
+					}
+
+					if fieldName == accessor.field.String() {
+						fieldItem = &item
+						break ITEMS_LOOP
+					}
 				}
 				var def *symbols.SymbolDef
 				var err error


### PR DESCRIPTION
Process kube-apiserver 1.9.0. Comparing with etcd 2.0.9:
```vi
$ ./checkapi --allocated apiserver.json --package-prefix github.com/coreos/etcd/client --allocated-godepsfile src/k8s.io/kubernetes/Godeps/Godeps.json --package-commit ${COMMIT} --godepsfile src/github.com/coreos/etcd/Godeps/Godeps.json --symbol-table-dir generated --go-version 1.9.2
Comparing github.com/coreos/etcd/client:0520cb9304cb2385f7e72b8bc02d6e4d3257158a with github.com/coreos/etcd/client:02697ca725e5c790cc1f9d0918ff22fad84cb4c5
?type "KeysAPI" changed
	used at k8s.io/apiserver/pkg/storage/etcd/etcd_helper.go:3036
	used at k8s.io/apiserver/pkg/storage/etcd/etcd_watcher.go:5568
	used at k8s.io/apiserver/pkg/storage/etcd/etcd_watcher.go:7257
?type "Watcher" changed
	used at k8s.io/apiserver/pkg/storage/etcd/etcd_watcher.go:6114
?type "Response" changed
	used at k8s.io/apiserver/pkg/storage/etcd/etcd_helper.go:10091
	used at k8s.io/apiserver/pkg/storage/etcd/etcd_helper.go:10687
	used at k8s.io/apiserver/pkg/storage/etcd/etcd_watcher.go:4448
	used at k8s.io/apiserver/pkg/storage/etcd/etcd_watcher.go:8217
	used at k8s.io/apiserver/pkg/storage/etcd/etcd_watcher.go:11153
	used at k8s.io/apiserver/pkg/storage/etcd/etcd_watcher.go:11908
	used at k8s.io/apiserver/pkg/storage/etcd/etcd_watcher.go:2566
	used at k8s.io/apiserver/pkg/storage/etcd/etcd_watcher.go:7329
	used at k8s.io/apiserver/pkg/storage/etcd/etcd_watcher.go:8249
	used at k8s.io/apiserver/pkg/storage/etcd/etcd_watcher.go:13628
	used at k8s.io/apiserver/pkg/storage/etcd/etcd_watcher.go:14617
?type "MembersAPI" changed
	used at k8s.io/apiserver/pkg/storage/etcd/etcd_helper.go:3004
?type "Node" changed
	used at k8s.io/apiserver/pkg/storage/etcd/etcd_helper.go:10789
	used at k8s.io/apiserver/pkg/storage/etcd/etcd_helper.go:12729
	used at k8s.io/apiserver/pkg/storage/etcd/etcd_helper.go:10075
	used at k8s.io/apiserver/pkg/storage/etcd/etcd_helper.go:15887
	used at k8s.io/apiserver/pkg/storage/etcd/etcd_helper.go:16239
	used at k8s.io/apiserver/pkg/storage/etcd/etcd_helper.go:13163
	used at k8s.io/apiserver/pkg/storage/etcd/etcd_watcher.go:8196
	used at k8s.io/apiserver/pkg/storage/etcd/etcd_watcher.go:10150
-type "Config" missing
	used at k8s.io/apiserver/pkg/storage/storagebackend/factory/etcd2.go:1444
-type "SetOptions" missing
	used at k8s.io/apiserver/pkg/storage/etcd/etcd_helper.go:5067
	used at k8s.io/apiserver/pkg/storage/etcd/etcd_helper.go:18691
	used at k8s.io/apiserver/pkg/storage/etcd/etcd_helper.go:19569
-type "Error" missing
	used at k8s.io/apiserver/pkg/storage/etcd/etcd_helper.go:16171
	used at k8s.io/apiserver/pkg/storage/etcd/etcd_watcher.go:7785
	used at k8s.io/apiserver/pkg/storage/etcd/util/etcd_util.go:1986
-type "WatcherOptions" missing
	used at k8s.io/apiserver/pkg/storage/etcd/etcd_watcher.go:6769
-type "Client" missing
	used at k8s.io/apiserver/pkg/storage/storagebackend/factory/etcd2.go:1386
	used at k8s.io/apiserver/pkg/storage/etcd/etcd_helper.go:2439
-type "DeleteOptions" missing
	used at k8s.io/apiserver/pkg/storage/etcd/etcd_helper.go:7656
-type "GetOptions" missing
	used at k8s.io/apiserver/pkg/storage/etcd/etcd_helper.go:12405
	used at k8s.io/apiserver/pkg/storage/etcd/etcd_helper.go:15976
	used at k8s.io/apiserver/pkg/storage/etcd/etcd_helper.go:10219
	used at k8s.io/apiserver/pkg/storage/etcd/etcd_watcher.go:7391
-function "ErrorCodeKeyNotFound" missing
	used at k8s.io/apiserver/pkg/storage/etcd/util/etcd_util.go:830
-function "PrevNoExist" missing
	used at k8s.io/apiserver/pkg/storage/etcd/etcd_helper.go:18772
	used at k8s.io/apiserver/pkg/storage/etcd/etcd_helper.go:5144
-function "ErrorCodeNodeExist" missing
	used at k8s.io/apiserver/pkg/storage/etcd/util/etcd_util.go:1015
-function "ErrorCodeTestFailed" missing
	used at k8s.io/apiserver/pkg/storage/etcd/util/etcd_util.go:1190
-function "ErrClusterUnavailable" missing
	used at k8s.io/apiserver/pkg/storage/etcd/util/etcd_util.go:1757
-function "ErrorCodeEventIndexCleared" missing
	used at k8s.io/apiserver/pkg/storage/etcd/util/etcd_util.go:1499
-function "New" missing
	used at k8s.io/apiserver/pkg/storage/storagebackend/factory/etcd2.go:1428
?function "NewKeysAPI" changed
	used at k8s.io/apiserver/pkg/storage/etcd/etcd_helper.go:2651
?function "NewMembersAPI" changed
	used at k8s.io/apiserver/pkg/storage/etcd/etcd_helper.go:2605

```