### PR TITLE
Compare kube-apiserver 1.9.0 with etcd-3.0.0

### DIFF
--- a/cmd/checkapi/checkapi.go
+++ b/cmd/checkapi/checkapi.go
@@ -437,14 +437,14 @@ func collectApiDiffs(tables map[string]allocglobal.PackageTable, packagePrefix s
 		}
 		refSDef, err := refSTable.LookupDataType(symbolItem.name)
 		if err != nil {
-			return nil, fmt.Errorf("Method %q of %q package not found", symbolItem.name, symbolItem.pkg)
+			return nil, fmt.Errorf("Field %q of %q package not found", symbolItem.name, symbolItem.pkg)
 		}
 
 		refMethodDef, err := refAccessor.RetrieveDataTypeField(
 			accessors.NewFieldAccessor(refSTable, refSDef, &ast.Ident{Name: symbolItem.field}),
 		)
 		if err != nil {
-			return nil, fmt.Errorf("Method %q of %q Type in %q package not found", symbolItem.field, symbolItem.name, symbolItem.pkg)
+			return nil, fmt.Errorf("Field %q of %q Type in %q package not found", symbolItem.field, symbolItem.name, symbolItem.pkg)
 		}
 
 		exerSTable, err := exercisedGlobalST.Lookup(symbolItem.pkg)


### PR DESCRIPTION
```vi
./checkapi --allocated apiserver.json --package-prefix github.com/coreos/etcd --allocated-godepsfile src/k8s.io/kubernetes/Godeps/Godeps.json --package-commit 6f48bda7ac36c8a53ce4210b06e5498947b08fab --godepsfile src/github.com/coreos/etcd/cmd/Godeps/Godeps.json --symbol-table-dir generated --go-version 1.9.2
Comparing github.com/coreos/etcd: with github.com/coreos/etcd:6f48bda7ac36c8a53ce4210b06e5498947b08fab
?type "github.com/coreos/etcd/pkg/transport.TLSInfo" changed
	used at k8s.io/apiserver/pkg/storage/storagebackend/factory/etcd2.go:1665
	used at k8s.io/apiserver/pkg/storage/storagebackend/factory/etcd3.go:960
?type "github.com/coreos/etcd/client.Response" changed
	used at k8s.io/apiserver/pkg/storage/etcd/etcd_helper.go:10091
	used at k8s.io/apiserver/pkg/storage/etcd/etcd_helper.go:10687
	used at k8s.io/apiserver/pkg/storage/etcd/etcd_watcher.go:13628
	used at k8s.io/apiserver/pkg/storage/etcd/etcd_watcher.go:14617
	used at k8s.io/apiserver/pkg/storage/etcd/etcd_watcher.go:8217
	used at k8s.io/apiserver/pkg/storage/etcd/etcd_watcher.go:11153
	used at k8s.io/apiserver/pkg/storage/etcd/etcd_watcher.go:4448
	used at k8s.io/apiserver/pkg/storage/etcd/etcd_watcher.go:2566
	used at k8s.io/apiserver/pkg/storage/etcd/etcd_watcher.go:11908
	used at k8s.io/apiserver/pkg/storage/etcd/etcd_watcher.go:7329
	used at k8s.io/apiserver/pkg/storage/etcd/etcd_watcher.go:8249
?type "github.com/coreos/etcd/clientv3.Client" changed
	used at k8s.io/apiserver/pkg/storage/etcd3/store.go:3136
	used at k8s.io/apiserver/pkg/storage/etcd3/store.go:2922
	used at k8s.io/apiserver/pkg/storage/etcd3/store.go:2027
	used at k8s.io/apiserver/pkg/storage/etcd3/store.go:2574
	used at k8s.io/apiserver/pkg/storage/etcd3/watcher.go:1838
	used at k8s.io/apiserver/pkg/storage/etcd3/watcher.go:2349
	used at k8s.io/apiserver/pkg/storage/etcd3/compact.go:1325
	used at k8s.io/apiserver/pkg/storage/etcd3/compact.go:2335
	used at k8s.io/apiserver/pkg/storage/etcd3/compact.go:4907
?type "github.com/coreos/etcd/client.SetOptions" changed
	used at k8s.io/apiserver/pkg/storage/etcd/etcd_helper.go:5067
	used at k8s.io/apiserver/pkg/storage/etcd/etcd_helper.go:18691
	used at k8s.io/apiserver/pkg/storage/etcd/etcd_helper.go:19569
?type "github.com/coreos/etcd/clientv3.Config" changed
	used at k8s.io/apiserver/pkg/storage/storagebackend/factory/etcd3.go:1339
-function "github.com/coreos/etcd/clientv3.WithPrevKV" missing
	used at k8s.io/apiserver/pkg/storage/etcd3/watcher.go:6002
-function "github.com/coreos/etcd/clientv3.GetPrefixRangeEnd" missing
	used at k8s.io/apiserver/pkg/storage/etcd3/store.go:16541
	used at k8s.io/apiserver/pkg/storage/etcd3/store.go:17107
-field "github.com/coreos/etcd/mvcc/mvccpb.Event.PrevKv" missing
	used at k8s.io/apiserver/pkg/storage/etcd3/event.go:1337
	used at k8s.io/apiserver/pkg/storage/etcd3/event.go:1373
```