### PR TITLE
Allow to process a library

### DIFF
--- a/cmd/extract/extract.go
+++ b/cmd/extract/extract.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"os/exec"
 	"path"
+	"path/filepath"
 	"runtime"
 	"sort"
 	"strings"
@@ -24,20 +25,48 @@ import (
 )
 
 type flags struct {
-	packagePath     *string
-	packagePrefix   *string
+	// Go package entry point
+	packagePath *string
+	// Import path prefix for the entry point
+	packagePrefix *string
+	// location of already extracted symbols (used for storing extracted symbols as well)
 	symbolTablePath *string
-	cgoSymbolsPath  *string
+	// location of symbols imported from the "C" package
+	cgoSymbolsPath *string
 
 	stdlib        *bool
 	allocated     *bool
 	recursiveFrom *string
 	filterPrefix  *string
 	perfile       *bool
+	pertree       *bool
 	allallocated  *bool
 	tojson        *bool
 	glidefile     *string
 	godepsfile    *string
+	// Interpret entry point as a library instead of a reachability tree
+	library *bool
+}
+
+func buildFlags() *flags {
+	return &flags{
+		packagePath:     flag.String("package-path", "", "Package entry point"),
+		packagePrefix:   flag.String("package-prefix", "", "Package import path prefix in a PACKAGE:COMMIT form"),
+		symbolTablePath: flag.String("symbol-table-dir", "", "Directory with preprocessed symbol tables"),
+		// TODO(jchaloup): extend it with a hiearchy of cgo symbol files
+		cgoSymbolsPath: flag.String("cgo-symbols-path", "", "Symbol table with CGO symbols (per entire project space)"),
+		stdlib:         flag.Bool("stdlib", false, "Parse system Go std library"),
+		allocated:      flag.Bool("allocated", false, "Extract allocation of symbols"),
+		recursiveFrom:  flag.String("recursive-from", "", "Extract allocation of symbols from all prefixed paths"),
+		filterPrefix:   flag.String("filter-prefix", "", "Filter out all imported packages from allocated symbols that does not match the prefix"),
+		perfile:        flag.Bool("per-file", false, "Display allocated symbols per file"),
+		pertree:        flag.Bool("per-tree", false, "Display allocated symbols per entire tree"),
+		allallocated:   flag.Bool("all-allocated", false, "Display all allocated symbols"),
+		tojson:         flag.Bool("json", false, "Display allocated symbols in JSON"),
+		glidefile:      flag.String("glidefile", "", "Glide.lock with dependencies"),
+		godepsfile:     flag.String("godepsfile", "", "Godeps.json with dependencies"),
+		library:        flag.Bool("library", false, "Interpret package entry point as a library"),
+	}
 }
 
 func (f *flags) parse() error {
@@ -66,29 +95,33 @@ func PrintAllocTables(allocTable *allocglobal.Table) {
 	}
 }
 
-func printPackageAllocTables(allocTable *allocglobal.Table, globalTable *global.Table, contractTable *contractglobal.Table, f *flags) error {
+func printPackageAllocTables(allocTable *allocglobal.Table, globalTable *global.Table, contractTable *contractglobal.Table, entryPoints []string, f *flags) error {
 
-	pkgs := strings.Split(*f.packagePath, ":")
 	perfile := *f.perfile
 	allallocated := *f.allallocated
 	tojson := *f.tojson
 
 	packageAllocTables := make(map[string]allocglobal.PackageTable)
 
-	// collect all packages with a given prefix
+	// collect all packages with a given prefix reachable from all the entry points
 	if *f.recursiveFrom != "" {
 		processed := make(map[string]struct{})
-		toProcess := pkgs
+		toProcess := entryPoints
 		for len(toProcess) > 0 {
+			if _, ok := processed[toProcess[0]]; ok {
+				toProcess = toProcess[1:]
+				continue
+			}
+
+			glog.V(1).Infof("Processing %v\n", toProcess[0])
 			st, err := globalTable.Lookup(toProcess[0])
 			if err != nil {
 				return err
 			}
 
+			processed[toProcess[0]] = struct{}{}
+
 			for _, p := range st.(*tables.Table).Imports {
-				if !strings.HasPrefix(p, *f.recursiveFrom) {
-					continue
-				}
 				if _, ok := processed[p]; ok {
 					continue
 				}
@@ -99,25 +132,45 @@ func printPackageAllocTables(allocTable *allocglobal.Table, globalTable *global.
 		}
 
 		for p := range processed {
+			if !strings.HasPrefix(p, *f.recursiveFrom) {
+				delete(processed, p)
+				continue
+			}
+
+			// Get the dynamic allocations
+			ct, err := contractTable.Lookup(p)
+			if err != nil {
+				return err
+			}
+			r := runner.New(p, globalTable, allocTable, ct)
+			if err := r.Run(); err != nil {
+				return fmt.Errorf("Unable to evaluate contracts for %v: %v", p, err)
+			}
+		}
+
+		for p := range processed {
 			tt, err := allocTable.LookupPackage(p)
 			if err != nil {
 				return err
 			}
-			if !tt.FilterOut("github.com/coreos/etcd") {
+
+			if !tt.FilterOut(*f.filterPrefix) {
 				packageAllocTables[p] = tt
-				// Get the dynamic allocations
-				ct, err := contractTable.Lookup(p)
-				if err != nil {
-					return err
-				}
-				r := runner.New(p, globalTable, allocTable, ct)
-				if err := r.Run(); err != nil {
-					return fmt.Errorf("Unable to evaluate contracts for %v: %v", p, err)
-				}
 			}
 		}
+
+		// if per-project is set, merge all tables into one
+		if *f.pertree {
+			cpTable := allocglobal.NewPackageTable()
+			for p, tt := range packageAllocTables {
+				cpTable.MergeWith(&tt)
+				delete(packageAllocTables, p)
+			}
+			packageAllocTables[*f.recursiveFrom] = *cpTable
+		}
+
 	} else {
-		for _, pkg := range pkgs {
+		for _, pkg := range entryPoints {
 			// Get the dynamic allocations
 			ct, err := contractTable.Lookup(pkg)
 			if err != nil {
@@ -146,8 +199,6 @@ func printPackageAllocTables(allocTable *allocglobal.Table, globalTable *global.
 		}
 	}
 
-	// Collect dynamic allocations
-
 	if tojson {
 		byteSlice, err := json.Marshal(packageAllocTables)
 		if err != nil {
@@ -158,7 +209,7 @@ func printPackageAllocTables(allocTable *allocglobal.Table, globalTable *global.
 	}
 
 	if perfile {
-		for _, pkg := range pkgs {
+		for _, pkg := range entryPoints {
 			allocTable.Print(pkg, allallocated)
 		}
 	} else {
@@ -213,6 +264,117 @@ func getStdlibPackages() ([]string, error) {
 	return packages, nil
 }
 
+func processStdlib(symbolTablePath, cgoSymbolsPath, goversion string) {
+	packages, err := getStdlibPackages()
+	if err != nil {
+		glog.Fatal(err)
+	}
+
+	generatedDir := path.Join(symbolTablePath, "golang", goversion)
+
+	for _, pkg := range packages {
+		fmt.Printf("Parsing %q...\n", pkg)
+		p, err := parser.New(generatedDir, cgoSymbolsPath, goversion, nil)
+		if err != nil {
+			panic(err)
+		}
+		if err := p.Parse(pkg, false); err != nil {
+			glog.Fatalf("Parse error when parsing (%v): %v", pkg, err)
+		}
+	}
+	return
+}
+
+func buildSnapshot(glidefile, godepsfile, packagePrefix string) (snapshots.Snapshot, error) {
+	if glidefile != "" {
+		sn, err := glide.GlideFromFile(glidefile)
+		if err != nil {
+			return nil, err
+		}
+		if packagePrefix != "" {
+			parts := strings.Split(packagePrefix, ":")
+			if len(parts) != 2 {
+				return nil, fmt.Errorf("Expected --package-prefix in a PACKAGE:COMMIT form")
+			}
+			sn.MainPackageCommit(parts[0], parts[1])
+		}
+		return sn, nil
+	}
+	if godepsfile != "" {
+		sn, err := godeps.FromFile(godepsfile)
+		if err != nil {
+			return nil, err
+		}
+		if packagePrefix != "" {
+			parts := strings.Split(packagePrefix, ":")
+			if len(parts) != 2 {
+				return nil, fmt.Errorf("Expected --package-prefix in a PACKAGE:COMMIT form")
+			}
+			sn.MainPackageCommit(parts[0], parts[1])
+		}
+		return sn, nil
+	}
+	panic("glidefile or godepsfile must be nonempty")
+}
+
+func exists(path string) (bool, error) {
+	_, err := os.Stat(path)
+	if err == nil {
+		return true, nil
+	}
+	if os.IsNotExist(err) {
+		return false, nil
+	}
+	return true, err
+}
+
+func buildEntryPoints(packagePath string, library bool) ([]string, error) {
+	if library {
+		gopath := os.Getenv("GOPATH")
+		if gopath == "" {
+			return nil, fmt.Errorf("GOPATH not set")
+		}
+
+		var abspath, pathPrefix string
+
+		for _, ep := range strings.Split(packagePath, ":") {
+			// first, find the absolute path
+			for _, gpath := range strings.Split(gopath, ":") {
+				abspath = path.Join(gpath, "src", ep)
+
+				if e, err := exists(abspath); err == nil && e {
+					pathPrefix = path.Join(gpath, "src")
+					break
+				}
+			}
+		}
+
+		pkgs := make(map[string]struct{})
+
+		visit := func(path string, info os.FileInfo, err error) error {
+			if !info.IsDir() {
+				if strings.HasSuffix(path, ".go") {
+					pkgs[filepath.Dir(path[len(pathPrefix)+1:])] = struct{}{}
+				}
+			}
+			return nil
+		}
+
+		err := filepath.Walk(abspath+"/", visit)
+		if err != nil {
+			return nil, err
+		}
+
+		var entryPoints []string
+		for p := range pkgs {
+			entryPoints = append(entryPoints, p)
+		}
+
+		return entryPoints, nil
+	}
+	return strings.Split(packagePath, ":"), nil
+}
+
 // Flow:
 // 1) if no go version is set, the system go stdlib is processed
 // 1.1) process builtin first (as it declares all built-in types (e.g. int, string, float),
@@ -230,22 +392,7 @@ func getStdlibPackages() ([]string, error) {
 // Later, one will specify a path to package symbol tables (each marked with corresponding commit)
 func main() {
 
-	f := &flags{
-		packagePath:     flag.String("package-path", "", "Package entry point"),
-		packagePrefix:   flag.String("package-prefix", "", "Package import path prefix in a PACKAGE:COMMIT form"),
-		symbolTablePath: flag.String("symbol-table-dir", "", "Directory with preprocessed symbol tables"),
-		// TODO(jchaloup): extend it with a hiearchy of cgo symbol files
-		cgoSymbolsPath: flag.String("cgo-symbols-path", "", "Symbol table with CGO symbols (per entire project space)"),
-		stdlib:         flag.Bool("stdlib", false, "Parse system Go std library"),
-		allocated:      flag.Bool("allocated", false, "Extract allocation of symbols"),
-		recursiveFrom:  flag.String("recursive-from", "", "Extract allocation of symbols from all prefixed paths"),
-		filterPrefix:   flag.String("filter-prefix", "", "Filter out all imported packages from allocated symbols that does not match the prefix"),
-		perfile:        flag.Bool("per-file", false, "Display allocated symbols per file"),
-		allallocated:   flag.Bool("all-allocated", false, "Display all allocated symbols"),
-		tojson:         flag.Bool("json", false, "Display allocated symbols in JSON"),
-		glidefile:      flag.String("glidefile", "", "Glide.lock with dependencies"),
-		godepsfile:     flag.String("godepsfile", "", "Godeps.json with dependencies"),
-	}
+	f := buildFlags()
 
 	if err := f.parse(); err != nil {
 		glog.Fatal(err)
@@ -263,67 +410,30 @@ func main() {
 
 	// parse the standard library
 	if *f.stdlib {
-		packages, err := getStdlibPackages()
-		if err != nil {
-			glog.Fatal(err)
-		}
-
-		generatedDir := path.Join(*(f.symbolTablePath), "golang", goversion)
-
-		for _, pkg := range packages {
-			fmt.Printf("Parsing %q...\n", pkg)
-			p, err := parser.New(generatedDir, *(f.cgoSymbolsPath), goversion, nil)
-			if err != nil {
-				panic(err)
-			}
-			if err := p.Parse(pkg, false); err != nil {
-				glog.Fatalf("Parse error when parsing (%v): %v", pkg, err)
-			}
-		}
+		processStdlib(*f.symbolTablePath, *f.cgoSymbolsPath, goversion)
 		return
 	}
 
-	var snapshot snapshots.Snapshot
-	if *f.glidefile != "" {
-		sn, err := glide.GlideFromFile(*f.glidefile)
-		if err != nil {
-			panic(err)
-		}
-		if *f.packagePrefix != "" {
-			parts := strings.Split(*f.packagePrefix, ":")
-			if len(parts) != 2 {
-				panic(fmt.Errorf("Expected --package-prefix in a PACKAGE:COMMIT form"))
-			}
-			sn.MainPackageCommit(parts[0], parts[1])
-		}
-		snapshot = sn
-	} else if *f.godepsfile != "" {
-		sn, err := godeps.FromFile(*f.godepsfile)
-		if err != nil {
-			panic(err)
-		}
-		if *f.packagePrefix != "" {
-			parts := strings.Split(*f.packagePrefix, ":")
-			if len(parts) != 2 {
-				panic(fmt.Errorf("Expected --package-prefix in a PACKAGE:COMMIT form"))
-			}
-			sn.MainPackageCommit(parts[0], parts[1])
-		}
-		snapshot = sn
+	snapshot, err := buildSnapshot(*f.glidefile, *f.godepsfile, *f.packagePrefix)
+	if err != nil {
+		glog.Fatal(err)
 	}
 
 	p, err := parser.New(*(f.symbolTablePath), *(f.cgoSymbolsPath), goversion, snapshot)
 	if err != nil {
-		panic(err)
+		glog.Fatal(err)
 	}
-	for _, pkgPath := range strings.Split(*f.packagePath, ":") {
+
+	entryPoints, _ := buildEntryPoints(*f.packagePath, *f.library)
+
+	for _, pkgPath := range entryPoints {
 		if err := p.Parse(pkgPath, *(f.allocated)); err != nil {
 			glog.Fatalf("Parse error: %v", err)
 		}
 	}
 
 	if *(f.allocated) {
-		if err := printPackageAllocTables(p.GlobalAllocTable(), p.GlobalSymbolTable(), p.GlobalContractsTable(), f); err != nil {
+		if err := printPackageAllocTables(p.GlobalAllocTable(), p.GlobalSymbolTable(), p.GlobalContractsTable(), entryPoints, f); err != nil {
 			fmt.Print(err)
 			os.Exit(1)
 		}

--- a/pkg/parser/alloctable/global/package_table.go
+++ b/pkg/parser/alloctable/global/package_table.go
@@ -1,0 +1,72 @@
+package global
+
+import (
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"strings"
+
+	"github.com/gofed/symbols-extractor/pkg/parser/alloctable"
+)
+
+type PackageTable map[string]*alloctable.Table
+
+func NewPackageTable() *PackageTable {
+	tt := make(PackageTable, 0)
+	return &tt
+}
+
+func (t *PackageTable) Load(file string) error {
+	raw, err := ioutil.ReadFile(file)
+	if err != nil {
+		return fmt.Errorf("Unable to load symbol table from %q: %v", file, err)
+	}
+
+	var table PackageTable
+	if err := json.Unmarshal(raw, &table); err != nil {
+		return fmt.Errorf("Unable to load symbol table from %q: %v", file, err)
+	}
+
+	*t = table
+	return nil
+}
+
+func (t *PackageTable) FilterOut(prefix string) bool {
+	emptyTable := true
+	for file, tab := range *t {
+		empty := true
+		for pkg := range tab.Symbols {
+			if !strings.HasPrefix(pkg, prefix) {
+				delete(tab.Symbols, pkg)
+				continue
+			}
+			empty = false
+		}
+		if empty {
+			delete(*t, file)
+			continue
+		}
+		emptyTable = false
+	}
+	return emptyTable
+}
+
+// Consolidate merges all per-file allocated tables into one
+func (t *PackageTable) Consolidate() {
+	cTable := alloctable.New("", "")
+
+	for file, table := range *t {
+		cTable.MergeWith(table)
+		delete(*t, file)
+	}
+	(*t)[""] = cTable
+}
+
+// Merge current table with passed one
+func (t *PackageTable) MergeWith(pt *PackageTable) {
+	t.Consolidate()
+
+	for _, table := range *pt {
+		(*t)[""].MergeWith(table)
+	}
+}

--- a/pkg/parser/alloctable/table.go
+++ b/pkg/parser/alloctable/table.go
@@ -70,6 +70,30 @@ func newPackage() *Package {
 	}
 }
 
+func (allSt *Table) MergeWith(pt *Table) {
+	for pkg, symbolSet := range pt.Symbols {
+		if _, ok := allSt.Symbols[pkg]; ok {
+			for _, item := range symbolSet.Datatypes {
+				allSt.AddDataType(pkg, item.Name, item.Pos)
+			}
+			for _, item := range symbolSet.Functions {
+				allSt.AddFunction(pkg, item.Name, item.Pos)
+			}
+			for _, item := range symbolSet.Variables {
+				allSt.AddVariable(pkg, item.Name, item.Pos)
+			}
+			for _, item := range symbolSet.Structfields {
+				allSt.AddStructField(pkg, item.Parent, item.Field, item.Pos)
+			}
+			for _, item := range symbolSet.Methods {
+				allSt.AddStructField(pkg, item.Parent, item.Name, item.Pos)
+			}
+		} else {
+			allSt.Symbols[pkg] = symbolSet
+		}
+	}
+}
+
 func (allSt *Table) Lock() {
 	allSt.locked = true
 }
@@ -86,7 +110,7 @@ func (allSt *Table) AddDataType(pkg, name, pos string) {
 	}
 
 	k := toKey(name, pos)
-	if _, ok := items.Functions[k]; ok {
+	if _, ok := items.Datatypes[k]; ok {
 		return
 	}
 

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -1,0 +1,94 @@
+package util
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"path"
+	"strings"
+
+	"github.com/golang/glog"
+)
+
+func ListGoFiles(packagePath string, cgo bool) ([]string, error) {
+
+	collectFiles := func(output string) []string {
+		line := strings.Split(string(output), "\n")[0]
+		line = line[1 : len(line)-1]
+		if line == "" {
+			return nil
+		}
+		return strings.Split(line, " ")
+	}
+	// check GOPATH/packagePath
+	filter := "{{.GoFiles}}"
+	if cgo {
+		filter = "{{.CgoFiles}}"
+	}
+	cmd := exec.Command("go", "list", "-f", filter, packagePath)
+	output, e := cmd.CombinedOutput()
+	if e == nil {
+		return collectFiles(string(output)), nil
+	}
+
+	if strings.Contains(string(output), "no buildable Go source files in") {
+		return nil, nil
+	}
+
+	// if strings.Contains(string(output), "no Go files in") {
+	// 	return nil, nil
+	// }
+
+	return nil, fmt.Errorf("%v: %v, %v", strings.Join(cmd.Args, " "), e, string(output))
+}
+
+func GetPackageFiles(packageRoot, packagePath string) (files []string, packageLocation string, err error) {
+
+	files, ppath, e := func() ([]string, string, error) {
+		var searched []string
+		// First searched the vendor directories
+		pathParts := strings.Split(packageRoot, string(os.PathSeparator))
+		for i := len(pathParts); i >= 0; i-- {
+			vendorpath := path.Join(path.Join(pathParts[:i]...), "vendor", packagePath)
+			glog.V(1).Infof("Checking %v directory", vendorpath)
+			if l, e := ListGoFiles(vendorpath, false); e == nil {
+				return l, vendorpath, e
+			}
+			searched = append(searched, vendorpath)
+		}
+
+		glog.V(1).Infof("Checking %v directory", packagePath)
+		if l, e := ListGoFiles(packagePath, false); e == nil {
+			return l, packagePath, e
+		}
+		searched = append(searched, packagePath)
+
+		return nil, "", fmt.Errorf("Unable to find %q in any of:\n\t\t%v\n", packagePath, strings.Join(searched, "\n\t\t"))
+	}()
+
+	if e != nil {
+		return nil, "", e
+	}
+
+	// cgo files enabled?
+	cgoFiles, e := ListGoFiles(ppath, true)
+	if e != nil {
+		return nil, "", e
+	}
+
+	if len(cgoFiles) > 0 {
+		files = append(files, cgoFiles...)
+	}
+
+	{
+		cmd := exec.Command("go", "list", "-f", "{{.Dir}}", ppath)
+		output, err := cmd.CombinedOutput()
+		if err != nil {
+			return nil, "", fmt.Errorf("go list -f {{.Dir}} %v failed: %v", ppath, err)
+		}
+		lines := strings.Split(string(output), "\n")
+		packageLocation = string(lines[0])
+	}
+
+	return files, packageLocation, nil
+}


### PR DESCRIPTION
To get something like (a list of all symbols from `k8s.io/apimachinary` imported in `k8s.io/client-go`):
```sh
$ ./extract --symbol-table-dir generated --cgo-symbols-path cgo/cgo.yml --package-path k8s.io/client-go --package-prefix k8s.io/client-go:a241087f9966deef6175a370da060f9623e92d94 --godepsfile src/k8s.io/kubernetes/Godeps/Godeps.json --library --allocated --recursive-from k8s.io/client-go --filter-prefix k8s.io/apimachinery --per-tree
```

with output:
```sh
======================================================================================================
	D: k8s.io/apimachinery/pkg/api/errors.APIStatus:                                     	1
	D: k8s.io/apimachinery/pkg/api/errors.StatusError:                                   	6
	D: k8s.io/apimachinery/pkg/api/errors.UnexpectedObjectError:                         	1
	D: k8s.io/apimachinery/pkg/api/meta.DefaultRESTMapper:                               	1
	D: k8s.io/apimachinery/pkg/api/meta.MultiRESTMapper:                                 	2
	D: k8s.io/apimachinery/pkg/api/meta.PriorityRESTMapper:                              	1
	D: k8s.io/apimachinery/pkg/api/meta.RESTMapper:                                      	9
	D: k8s.io/apimachinery/pkg/api/meta.RESTMapping:                                     	2
	D: k8s.io/apimachinery/pkg/api/meta.VersionInterfaces:                               	2
	D: k8s.io/apimachinery/pkg/api/meta.VersionInterfacesFunc:                           	4
	D: k8s.io/apimachinery/pkg/apis/meta/internalversion.List:                           	2
	D: k8s.io/apimachinery/pkg/apis/meta/v1.APIGroup:                                    	5
	D: k8s.io/apimachinery/pkg/apis/meta/v1.APIGroupList:                                	10
	D: k8s.io/apimachinery/pkg/apis/meta/v1.APIResource:                                 	12
	D: k8s.io/apimachinery/pkg/apis/meta/v1.APIResourceList:                             	39
	D: k8s.io/apimachinery/pkg/apis/meta/v1.APIVersions:                                 	3
	D: k8s.io/apimachinery/pkg/apis/meta/v1.Common:                                      	1
	D: k8s.io/apimachinery/pkg/apis/meta/v1.DeleteOptions:                               	369
	D: k8s.io/apimachinery/pkg/apis/meta/v1.GetOptions:                                  	203
	D: k8s.io/apimachinery/pkg/apis/meta/v1.GroupVersionForDiscovery:                    	4
	D: k8s.io/apimachinery/pkg/apis/meta/v1.LabelSelector:                               	4
	D: k8s.io/apimachinery/pkg/apis/meta/v1.ListOptions:                                 	705
	D: k8s.io/apimachinery/pkg/apis/meta/v1.Object:                                      	1
	D: k8s.io/apimachinery/pkg/apis/meta/v1.ObjectMeta:                                  	14
	D: k8s.io/apimachinery/pkg/apis/meta/v1.Status:                                      	7
	D: k8s.io/apimachinery/pkg/apis/meta/v1.Time:                                        	9
	D: k8s.io/apimachinery/pkg/apis/meta/v1.TypeMeta:                                    	2
	D: k8s.io/apimachinery/pkg/apis/meta/v1.WatchEvent:                                  	2
	D: k8s.io/apimachinery/pkg/apis/meta/v1/unstructured.Unstructured:                   	33
	D: k8s.io/apimachinery/pkg/apis/meta/v1/unstructured.UnstructuredList:               	3
	D: k8s.io/apimachinery/pkg/apis/meta/v1/unstructured.UnstructuredObjectConverter:    	1
	D: k8s.io/apimachinery/pkg/conversion.Scope:                                         	54
	D: k8s.io/apimachinery/pkg/fields.Selector:                                          	7
	D: k8s.io/apimachinery/pkg/fields.Set:                                               	1
	D: k8s.io/apimachinery/pkg/labels.Selector:                                          	255
	D: k8s.io/apimachinery/pkg/labels.Set:                                               	85
	D: k8s.io/apimachinery/pkg/runtime.Codec:                                            	1
	D: k8s.io/apimachinery/pkg/runtime.Decoder:                                          	8
	D: k8s.io/apimachinery/pkg/runtime.Encoder:                                          	3
	D: k8s.io/apimachinery/pkg/runtime.Framer:                                           	1
	D: k8s.io/apimachinery/pkg/runtime.GroupVersioner:                                   	1
	D: k8s.io/apimachinery/pkg/runtime.NegotiatedSerializer:                             	2
	D: k8s.io/apimachinery/pkg/runtime.NoopEncoder:                                      	1
	D: k8s.io/apimachinery/pkg/runtime.Object:                                           	211
	D: k8s.io/apimachinery/pkg/runtime.ObjectCreater:                                    	1
	D: k8s.io/apimachinery/pkg/runtime.ObjectTyper:                                      	5
	D: k8s.io/apimachinery/pkg/runtime.ParameterCodec:                                   	8
	D: k8s.io/apimachinery/pkg/runtime.RawExtension:                                     	3
	D: k8s.io/apimachinery/pkg/runtime.Scheme:                                           	25
	D: k8s.io/apimachinery/pkg/runtime.SchemeBuilder:                                    	1
	D: k8s.io/apimachinery/pkg/runtime.Serializer:                                       	1
	D: k8s.io/apimachinery/pkg/runtime.SerializerInfo:                                   	2
	D: k8s.io/apimachinery/pkg/runtime.Unstructured:                                     	1
	D: k8s.io/apimachinery/pkg/runtime/schema.GroupKind:                                 	9
	D: k8s.io/apimachinery/pkg/runtime/schema.GroupResource:                             	21
	D: k8s.io/apimachinery/pkg/runtime/schema.GroupVersion:                              	46
	D: k8s.io/apimachinery/pkg/runtime/schema.GroupVersionKind:                          	109
	D: k8s.io/apimachinery/pkg/runtime/schema.GroupVersionResource:                      	141
	D: k8s.io/apimachinery/pkg/runtime/schema.GroupVersions:                             	1
	D: k8s.io/apimachinery/pkg/runtime/schema.ObjectKind:                                	2
	D: k8s.io/apimachinery/pkg/runtime/serializer.CodecFactory:                          	2
	D: k8s.io/apimachinery/pkg/runtime/serializer.DirectCodecFactory:                    	29
	D: k8s.io/apimachinery/pkg/runtime/serializer/streaming.Decoder:                     	2
	D: k8s.io/apimachinery/pkg/runtime/serializer/streaming.Encoder:                     	2
	D: k8s.io/apimachinery/pkg/types.NodeName:                                           	1
	D: k8s.io/apimachinery/pkg/types.PatchType:                                          	187
	D: k8s.io/apimachinery/pkg/types.UID:                                                	1
	D: k8s.io/apimachinery/pkg/util/cache.LRUExpireCache:                                	1
	D: k8s.io/apimachinery/pkg/util/clock.Clock:                                         	18
	D: k8s.io/apimachinery/pkg/util/clock.FakeClock:                                     	1
	D: k8s.io/apimachinery/pkg/util/clock.RealClock:                                     	10
	D: k8s.io/apimachinery/pkg/util/errors.Aggregate:                                    	1
	D: k8s.io/apimachinery/pkg/util/httpstream.Connection:                               	4
	D: k8s.io/apimachinery/pkg/util/httpstream.Dialer:                                   	4
	D: k8s.io/apimachinery/pkg/util/httpstream.Stream:                                   	5
	D: k8s.io/apimachinery/pkg/util/net.RoundTripperWrapper:                             	4
	D: k8s.io/apimachinery/pkg/util/sets.String:                                         	7
	D: k8s.io/apimachinery/pkg/util/wait.Backoff:                                        	5
	D: k8s.io/apimachinery/pkg/util/wait.Group:                                          	3
	D: k8s.io/apimachinery/pkg/version.Info:                                             	10
	D: k8s.io/apimachinery/pkg/watch.Broadcaster:                                        	3
	D: k8s.io/apimachinery/pkg/watch.ConditionFunc:                                      	1
	D: k8s.io/apimachinery/pkg/watch.Event:                                              	15
	D: k8s.io/apimachinery/pkg/watch.EventType:                                          	2
	D: k8s.io/apimachinery/pkg/watch.FakeWatcher:                                        	5
	D: k8s.io/apimachinery/pkg/watch.Interface:                                          	267
	F: k8s.io/apimachinery/pkg/api/errors.FromObject:                                    	4
	F: k8s.io/apimachinery/pkg/api/errors.IsAlreadyExists:                               	2
	F: k8s.io/apimachinery/pkg/api/errors.IsConflict:                                    	1
	F: k8s.io/apimachinery/pkg/api/errors.IsForbidden:                                   	5
	F: k8s.io/apimachinery/pkg/api/errors.IsNotFound:                                    	8
	F: k8s.io/apimachinery/pkg/api/errors.IsResourceExpired:                             	1
	F: k8s.io/apimachinery/pkg/api/errors.IsUnauthorized:                                	1
	F: k8s.io/apimachinery/pkg/api/errors.IsUnexpectedServerError:                       	2
	F: k8s.io/apimachinery/pkg/api/errors.NewAlreadyExists:                              	1
	F: k8s.io/apimachinery/pkg/api/errors.NewBadRequest:                                 	1
	F: k8s.io/apimachinery/pkg/api/errors.NewGenericServerResponse:                      	1
	F: k8s.io/apimachinery/pkg/api/errors.NewInternalError:                              	1
	F: k8s.io/apimachinery/pkg/api/errors.NewNotFound:                                   	79
	F: k8s.io/apimachinery/pkg/api/meta.Accessor:                                        	17
	F: k8s.io/apimachinery/pkg/api/meta.CommonAccessor:                                  	1
	F: k8s.io/apimachinery/pkg/api/meta.EachListItem:                                    	1
	F: k8s.io/apimachinery/pkg/api/meta.ExtractList:                                     	3
	F: k8s.io/apimachinery/pkg/api/meta.IsListType:                                      	2
	F: k8s.io/apimachinery/pkg/api/meta.IsNoMatchError:                                  	1
	F: k8s.io/apimachinery/pkg/api/meta.ListAccessor:                                    	6
	F: k8s.io/apimachinery/pkg/api/meta.NewAccessor:                                     	1
	F: k8s.io/apimachinery/pkg/api/meta.NewDefaultRESTMapper:                            	2
	F: k8s.io/apimachinery/pkg/api/meta.SetList:                                         	4
	F: k8s.io/apimachinery/pkg/api/meta.UnsafeGuessKindToResource:                       	3
	F: k8s.io/apimachinery/pkg/apis/meta/v1.AddToGroupVersion:                           	2
	F: k8s.io/apimachinery/pkg/apis/meta/v1.ExtractGroupVersions:                        	2
	F: k8s.io/apimachinery/pkg/apis/meta/v1.LabelSelectorAsSelector:                     	19
	F: k8s.io/apimachinery/pkg/apis/meta/v1.NewTime:                                     	2
	F: k8s.io/apimachinery/pkg/apis/meta/v1.Now:                                         	2
	F: k8s.io/apimachinery/pkg/apis/meta/v1.ParseToLabelSelector:                        	3
	F: k8s.io/apimachinery/pkg/conversion/queryparams.Convert:                           	1
	F: k8s.io/apimachinery/pkg/fields.Everything:                                        	3
	F: k8s.io/apimachinery/pkg/fields.OneTermEqualSelector:                              	1
	F: k8s.io/apimachinery/pkg/fields.ParseSelector:                                     	1
	F: k8s.io/apimachinery/pkg/labels.Everything:                                        	81
	F: k8s.io/apimachinery/pkg/labels.Parse:                                             	1
	F: k8s.io/apimachinery/pkg/runtime.Decode:                                           	3
	F: k8s.io/apimachinery/pkg/runtime.DecodeList:                                       	1
	F: k8s.io/apimachinery/pkg/runtime.Encode:                                           	4
	F: k8s.io/apimachinery/pkg/runtime.IsNotRegisteredError:                             	1
	F: k8s.io/apimachinery/pkg/runtime.NewMissingKindErr:                                	1
	F: k8s.io/apimachinery/pkg/runtime.NewMissingVersionErr:                             	1
	F: k8s.io/apimachinery/pkg/runtime.NewMultiGroupVersioner:                           	1
	F: k8s.io/apimachinery/pkg/runtime.NewNotRegisteredErrForType:                       	1
	F: k8s.io/apimachinery/pkg/runtime.NewParameterCodec:                                	2
	F: k8s.io/apimachinery/pkg/runtime.NewScheme:                                        	4
	F: k8s.io/apimachinery/pkg/runtime.NewSchemeBuilder:                                 	4
	F: k8s.io/apimachinery/pkg/runtime.SerializerInfoForMediaType:                       	3
	F: k8s.io/apimachinery/pkg/runtime/schema.FromAPIVersionAndKind:                     	2
	F: k8s.io/apimachinery/pkg/runtime/schema.ParseGroupVersion:                         	4
	F: k8s.io/apimachinery/pkg/runtime/serializer.NegotiatedSerializerWrapper:           	2
	F: k8s.io/apimachinery/pkg/runtime/serializer.NewCodecFactory:                       	4
	F: k8s.io/apimachinery/pkg/runtime/serializer/json.NewYAMLSerializer:                	1
	F: k8s.io/apimachinery/pkg/runtime/serializer/streaming.NewDecoder:                  	1
	F: k8s.io/apimachinery/pkg/runtime/serializer/versioning.NewDefaultingCodecForScheme:	1
	F: k8s.io/apimachinery/pkg/util/cache.NewLRUExpireCache:                             	1
	F: k8s.io/apimachinery/pkg/util/diff.ObjectDiff:                                     	1
	F: k8s.io/apimachinery/pkg/util/errors.NewAggregate:                                 	2
	F: k8s.io/apimachinery/pkg/util/httpstream/spdy.NewRoundTripper:                     	1
	F: k8s.io/apimachinery/pkg/util/net.CloneRequest:                                    	5
	F: k8s.io/apimachinery/pkg/util/net.IsConnectionReset:                               	1
	F: k8s.io/apimachinery/pkg/util/net.IsProbableEOF:                                   	1
	F: k8s.io/apimachinery/pkg/util/net.JoinSchemeNamePort:                              	1
	F: k8s.io/apimachinery/pkg/util/net.SetTransportDefaults:                            	1
	F: k8s.io/apimachinery/pkg/util/runtime.HandleCrash:                                 	15
	F: k8s.io/apimachinery/pkg/util/runtime.HandleError:                                 	35
	F: k8s.io/apimachinery/pkg/util/sets.NewInt:                                         	1
	F: k8s.io/apimachinery/pkg/util/sets.NewString:                                      	6
	F: k8s.io/apimachinery/pkg/util/sets.StringKeySet:                                   	2
	F: k8s.io/apimachinery/pkg/util/strategicpatch.CreateTwoWayMergePatch:               	1
	F: k8s.io/apimachinery/pkg/util/validation.IsDNS1123Label:                           	1
	F: k8s.io/apimachinery/pkg/util/wait.ExponentialBackoff:                             	4
	F: k8s.io/apimachinery/pkg/util/wait.Forever:                                        	1
	F: k8s.io/apimachinery/pkg/util/wait.Jitter:                                         	1
	F: k8s.io/apimachinery/pkg/util/wait.JitterUntil:                                    	1
	F: k8s.io/apimachinery/pkg/util/wait.Poll:                                           	1
	F: k8s.io/apimachinery/pkg/util/wait.PollInfinite:                                   	1
	F: k8s.io/apimachinery/pkg/util/wait.PollUntil:                                      	1
	F: k8s.io/apimachinery/pkg/util/wait.Until:                                          	5
	F: k8s.io/apimachinery/pkg/util/yaml.ToJSON:                                         	1
	F: k8s.io/apimachinery/pkg/watch.NewBroadcaster:                                     	5
	F: k8s.io/apimachinery/pkg/watch.NewEmptyWatch:                                      	1
	F: k8s.io/apimachinery/pkg/watch.NewFakeWithChanSize:                                	1
	F: k8s.io/apimachinery/pkg/watch.NewStreamWatcher:                                   	1
	F: k8s.io/apimachinery/pkg/watch.Until:                                              	1
	M: k8s.io/apimachinery/pkg/apis/meta/v1/unstructured.Unstructured.GetLabels:         	1
	M: k8s.io/apimachinery/pkg/runtime/serializer.CodecFactory.UniversalDecoder:         	1
	M: k8s.io/apimachinery/pkg/util/cache.LRUExpireCache.Add:                            	1
	M: k8s.io/apimachinery/pkg/util/cache.LRUExpireCache.Get:                            	4
	M: k8s.io/apimachinery/pkg/util/cache.LRUExpireCache.Keys:                           	1
	M: k8s.io/apimachinery/pkg/util/cache.LRUExpireCache.Remove:                         	1
	M: k8s.io/apimachinery/pkg/util/sets.String.Has:                                     	1
	M: k8s.io/apimachinery/pkg/util/sets.String.Insert:                                  	1
	S: k8s.io/apimachinery/pkg/api/errors.StatusError.ErrStatus:                         	6
	S: k8s.io/apimachinery/pkg/api/errors.StatusError.Status:                            	1
	S: k8s.io/apimachinery/pkg/api/meta.DefaultRESTMapper.Add:                           	5
	S: k8s.io/apimachinery/pkg/api/meta.DefaultRESTMapper.AddSpecific:                   	1
	S: k8s.io/apimachinery/pkg/api/meta.PriorityRESTMapper.Delegate:                     	1
	S: k8s.io/apimachinery/pkg/api/meta.PriorityRESTMapper.KindPriority:                 	1
	S: k8s.io/apimachinery/pkg/api/meta.PriorityRESTMapper.ResourcePriority:             	1
	S: k8s.io/apimachinery/pkg/api/meta.VersionInterfaces.MetadataAccessor:              	1
	S: k8s.io/apimachinery/pkg/api/meta.VersionInterfaces.ObjectConvertor:               	1
	S: k8s.io/apimachinery/pkg/apis/meta/internalversion.List.Items:                     	3
	S: k8s.io/apimachinery/pkg/apis/meta/v1.APIGroup.Name:                               	11
	S: k8s.io/apimachinery/pkg/apis/meta/v1.APIGroup.PreferredVersion:                   	8
	S: k8s.io/apimachinery/pkg/apis/meta/v1.APIGroup.Versions:                           	10
	S: k8s.io/apimachinery/pkg/apis/meta/v1.APIGroupList.Groups:                         	10
	S: k8s.io/apimachinery/pkg/apis/meta/v1.APIResource.Group:                           	2
	S: k8s.io/apimachinery/pkg/apis/meta/v1.APIResource.Kind:                            	9
	S: k8s.io/apimachinery/pkg/apis/meta/v1.APIResource.Name:                            	14
	S: k8s.io/apimachinery/pkg/apis/meta/v1.APIResource.Namespaced:                      	11
	S: k8s.io/apimachinery/pkg/apis/meta/v1.APIResource.SingularName:                    	2
	S: k8s.io/apimachinery/pkg/apis/meta/v1.APIResource.Verbs:                           	1
	S: k8s.io/apimachinery/pkg/apis/meta/v1.APIResource.Version:                         	2
	S: k8s.io/apimachinery/pkg/apis/meta/v1.APIResourceList.APIResources:                	18
	S: k8s.io/apimachinery/pkg/apis/meta/v1.APIResourceList.GroupVersion:                	11
	S: k8s.io/apimachinery/pkg/apis/meta/v1.APIVersions.Versions:                        	4
	S: k8s.io/apimachinery/pkg/apis/meta/v1.DeleteOptions.PropagationPolicy:             	1
	S: k8s.io/apimachinery/pkg/apis/meta/v1.GroupVersionForDiscovery.GroupVersion:       	12
	S: k8s.io/apimachinery/pkg/apis/meta/v1.GroupVersionForDiscovery.Version:            	21
	S: k8s.io/apimachinery/pkg/apis/meta/v1.LabelSelector.DeepCopyInto:                  	1
	S: k8s.io/apimachinery/pkg/apis/meta/v1.LabelSelector.MatchExpressions:              	4
	S: k8s.io/apimachinery/pkg/apis/meta/v1.LabelSelector.MatchLabels:                   	4
	S: k8s.io/apimachinery/pkg/apis/meta/v1.ListMeta.ResourceVersion:                    	1
	S: k8s.io/apimachinery/pkg/apis/meta/v1.ListMeta.SelfLink:                           	1
	S: k8s.io/apimachinery/pkg/apis/meta/v1.ListOptions.Continue:                        	2
	S: k8s.io/apimachinery/pkg/apis/meta/v1.ListOptions.FieldSelector:                   	6
	S: k8s.io/apimachinery/pkg/apis/meta/v1.ListOptions.LabelSelector:                   	2
	S: k8s.io/apimachinery/pkg/apis/meta/v1.ListOptions.Limit:                           	4
	S: k8s.io/apimachinery/pkg/apis/meta/v1.ListOptions.ResourceVersion:                 	5
	S: k8s.io/apimachinery/pkg/apis/meta/v1.ListOptions.TimeoutSeconds:                  	3
	S: k8s.io/apimachinery/pkg/apis/meta/v1.ListOptions.Watch:                           	63
	S: k8s.io/apimachinery/pkg/apis/meta/v1.ObjectMeta.Annotations:                      	10
	S: k8s.io/apimachinery/pkg/apis/meta/v1.ObjectMeta.DeepCopyInto:                     	1
	S: k8s.io/apimachinery/pkg/apis/meta/v1.ObjectMeta.GenerateName:                     	1
	S: k8s.io/apimachinery/pkg/apis/meta/v1.ObjectMeta.GetName:                          	1
	S: k8s.io/apimachinery/pkg/apis/meta/v1.ObjectMeta.GetObjectMeta:                    	1
	S: k8s.io/apimachinery/pkg/apis/meta/v1.ObjectMeta.Labels:                           	113
	S: k8s.io/apimachinery/pkg/apis/meta/v1.ObjectMeta.Name:                             	155
	S: k8s.io/apimachinery/pkg/apis/meta/v1.ObjectMeta.Namespace:                        	82
	S: k8s.io/apimachinery/pkg/apis/meta/v1.ObjectMeta.ResourceVersion:                  	4
	S: k8s.io/apimachinery/pkg/apis/meta/v1.ObjectMeta.UID:                              	2
	S: k8s.io/apimachinery/pkg/apis/meta/v1.Status.Code:                                 	1
	S: k8s.io/apimachinery/pkg/apis/meta/v1.Status.Details:                              	3
	S: k8s.io/apimachinery/pkg/apis/meta/v1.Status.Message:                              	5
	S: k8s.io/apimachinery/pkg/apis/meta/v1.Status.Reason:                               	1
	S: k8s.io/apimachinery/pkg/apis/meta/v1.Status.Status:                               	5
	S: k8s.io/apimachinery/pkg/apis/meta/v1.StatusCause.Message:                         	2
	S: k8s.io/apimachinery/pkg/apis/meta/v1.StatusCause.Type:                            	1
	S: k8s.io/apimachinery/pkg/apis/meta/v1.StatusDetails.Causes:                        	2
	S: k8s.io/apimachinery/pkg/apis/meta/v1.Time.Time:                                   	4
	S: k8s.io/apimachinery/pkg/apis/meta/v1.TypeMeta.Kind:                               	1
	S: k8s.io/apimachinery/pkg/apis/meta/v1.WatchEvent.Object:                           	2
	S: k8s.io/apimachinery/pkg/apis/meta/v1.WatchEvent.Type:                             	4
	S: k8s.io/apimachinery/pkg/apis/meta/v1/unstructured.Unstructured.GetName:           	2
	S: k8s.io/apimachinery/pkg/apis/meta/v1/unstructured.UnstructuredList.Items:         	3
	S: k8s.io/apimachinery/pkg/fields.Set.AsSelector:                                    	1
	S: k8s.io/apimachinery/pkg/labels.Set.AsSelectorPreValidated:                        	2
	S: k8s.io/apimachinery/pkg/runtime.NoopEncoder.Decoder:                              	1
	S: k8s.io/apimachinery/pkg/runtime.RawExtension.Raw:                                 	2
	S: k8s.io/apimachinery/pkg/runtime.Scheme.AddConversionFuncs:                        	4
	S: k8s.io/apimachinery/pkg/runtime.Scheme.AddGeneratedConversionFuncs:               	3
	S: k8s.io/apimachinery/pkg/runtime.Scheme.AddKnownTypes:                             	5
	S: k8s.io/apimachinery/pkg/runtime.Scheme.ConvertToVersion:                          	2
	S: k8s.io/apimachinery/pkg/runtime.Scheme.ObjectKinds:                               	1
	S: k8s.io/apimachinery/pkg/runtime.SchemeBuilder.AddToScheme:                        	8
	S: k8s.io/apimachinery/pkg/runtime.SchemeBuilder.Register:                           	7
	S: k8s.io/apimachinery/pkg/runtime.SerializerInfo.MediaType:                         	1
	S: k8s.io/apimachinery/pkg/runtime.SerializerInfo.PrettySerializer:                  	1
	S: k8s.io/apimachinery/pkg/runtime.SerializerInfo.Serializer:                        	7
	S: k8s.io/apimachinery/pkg/runtime.SerializerInfo.StreamSerializer:                  	6
	S: k8s.io/apimachinery/pkg/runtime.StreamSerializerInfo.Framer:                      	2
	S: k8s.io/apimachinery/pkg/runtime.StreamSerializerInfo.Serializer:                  	2
	S: k8s.io/apimachinery/pkg/runtime/schema.GroupKind.Group:                           	4
	S: k8s.io/apimachinery/pkg/runtime/schema.GroupKind.Kind:                            	4
	S: k8s.io/apimachinery/pkg/runtime/schema.GroupResource.Group:                       	3
	S: k8s.io/apimachinery/pkg/runtime/schema.GroupResource.Resource:                    	2
	S: k8s.io/apimachinery/pkg/runtime/schema.GroupResource.String:                      	5
	S: k8s.io/apimachinery/pkg/runtime/schema.GroupResource.WithVersion:                 	3
	S: k8s.io/apimachinery/pkg/runtime/schema.GroupVersion.Group:                        	27
	S: k8s.io/apimachinery/pkg/runtime/schema.GroupVersion.String:                       	4
	S: k8s.io/apimachinery/pkg/runtime/schema.GroupVersion.Version:                      	26
	S: k8s.io/apimachinery/pkg/runtime/schema.GroupVersion.WithKind:                     	15
	S: k8s.io/apimachinery/pkg/runtime/schema.GroupVersion.WithResource:                 	82
	S: k8s.io/apimachinery/pkg/runtime/schema.GroupVersionKind.Group:                    	66
	S: k8s.io/apimachinery/pkg/runtime/schema.GroupVersionKind.GroupKind:                	3
	S: k8s.io/apimachinery/pkg/runtime/schema.GroupVersionKind.GroupVersion:             	5
	S: k8s.io/apimachinery/pkg/runtime/schema.GroupVersionKind.Kind:                     	74
	S: k8s.io/apimachinery/pkg/runtime/schema.GroupVersionKind.ToAPIVersionAndKind:      	2
	S: k8s.io/apimachinery/pkg/runtime/schema.GroupVersionKind.Version:                  	70
	S: k8s.io/apimachinery/pkg/runtime/schema.GroupVersionResource.Group:                	67
	S: k8s.io/apimachinery/pkg/runtime/schema.GroupVersionResource.GroupResource:        	72
	S: k8s.io/apimachinery/pkg/runtime/schema.GroupVersionResource.GroupVersion:         	4
	S: k8s.io/apimachinery/pkg/runtime/schema.GroupVersionResource.Resource:             	84
	S: k8s.io/apimachinery/pkg/runtime/schema.GroupVersionResource.String:               	3
	S: k8s.io/apimachinery/pkg/runtime/schema.GroupVersionResource.Version:              	69
	S: k8s.io/apimachinery/pkg/runtime/serializer.CodecFactory.LegacyCodec:              	1
	S: k8s.io/apimachinery/pkg/runtime/serializer.CodecFactory.SupportedMediaTypes:      	1
	S: k8s.io/apimachinery/pkg/runtime/serializer.CodecFactory.UniversalDecoder:         	3
	S: k8s.io/apimachinery/pkg/runtime/serializer.DirectCodecFactory.CodecFactory:       	29
	S: k8s.io/apimachinery/pkg/util/sets.Int.Has:                                        	1
	S: k8s.io/apimachinery/pkg/util/sets.String.Delete:                                  	1
	S: k8s.io/apimachinery/pkg/util/sets.String.Has:                                     	6
	S: k8s.io/apimachinery/pkg/util/sets.String.HasAll:                                  	1
	S: k8s.io/apimachinery/pkg/util/sets.String.HasAny:                                  	1
	S: k8s.io/apimachinery/pkg/util/sets.String.Insert:                                  	7
	S: k8s.io/apimachinery/pkg/util/sets.String.Intersection:                            	1
	S: k8s.io/apimachinery/pkg/util/sets.String.Len:                                     	3
	S: k8s.io/apimachinery/pkg/util/sets.String.List:                                    	4
	S: k8s.io/apimachinery/pkg/util/sets.String.PopAny:                                  	1
	S: k8s.io/apimachinery/pkg/util/sets.String.UnsortedList:                            	1
	S: k8s.io/apimachinery/pkg/util/wait.Backoff.Duration:                               	4
	S: k8s.io/apimachinery/pkg/util/wait.Backoff.Factor:                                 	4
	S: k8s.io/apimachinery/pkg/util/wait.Backoff.Jitter:                                 	4
	S: k8s.io/apimachinery/pkg/util/wait.Backoff.Steps:                                  	4
	S: k8s.io/apimachinery/pkg/util/wait.Group.Start:                                    	4
	S: k8s.io/apimachinery/pkg/util/wait.Group.StartWithChannel:                         	3
	S: k8s.io/apimachinery/pkg/util/wait.Group.Wait:                                     	3
	S: k8s.io/apimachinery/pkg/version.Info.BuildDate:                                   	1
	S: k8s.io/apimachinery/pkg/version.Info.Compiler:                                    	1
	S: k8s.io/apimachinery/pkg/version.Info.GitCommit:                                   	4
	S: k8s.io/apimachinery/pkg/version.Info.GitTreeState:                                	3
	S: k8s.io/apimachinery/pkg/version.Info.GitVersion:                                  	4
	S: k8s.io/apimachinery/pkg/version.Info.GoVersion:                                   	1
	S: k8s.io/apimachinery/pkg/version.Info.Major:                                       	1
	S: k8s.io/apimachinery/pkg/version.Info.Minor:                                       	1
	S: k8s.io/apimachinery/pkg/version.Info.Platform:                                    	1
	S: k8s.io/apimachinery/pkg/watch.Broadcaster.Action:                                 	2
	S: k8s.io/apimachinery/pkg/watch.Broadcaster.Shutdown:                               	1
	S: k8s.io/apimachinery/pkg/watch.Broadcaster.Watch:                                  	2
	S: k8s.io/apimachinery/pkg/watch.Broadcaster.WatchWithPrefix:                        	1
	S: k8s.io/apimachinery/pkg/watch.Event.Object:                                       	25
	S: k8s.io/apimachinery/pkg/watch.Event.Type:                                         	15
	S: k8s.io/apimachinery/pkg/watch.FakeWatcher.Add:                                    	1
	S: k8s.io/apimachinery/pkg/watch.FakeWatcher.Delete:                                 	1
	S: k8s.io/apimachinery/pkg/watch.FakeWatcher.Modify:                                 	1
	V: k8s.io/apimachinery/pkg/api/meta.AnyKind:                                         	4
	V: k8s.io/apimachinery/pkg/api/meta.AnyResource:                                     	4
	V: k8s.io/apimachinery/pkg/api/meta.AnyVersion:                                      	2
	V: k8s.io/apimachinery/pkg/api/meta.RESTScopeNamespace:                              	2
	V: k8s.io/apimachinery/pkg/api/meta.RESTScopeRoot:                                   	3
	V: k8s.io/apimachinery/pkg/apis/meta/v1.DeletePropagationForeground:                 	1
	V: k8s.io/apimachinery/pkg/apis/meta/v1.NamespaceAll:                                	2
	V: k8s.io/apimachinery/pkg/apis/meta/v1.NamespaceDefault:                            	1
	V: k8s.io/apimachinery/pkg/apis/meta/v1.ParameterCodec:                              	2
	V: k8s.io/apimachinery/pkg/apis/meta/v1.SchemeGroupVersion:                          	1
	V: k8s.io/apimachinery/pkg/apis/meta/v1.StatusFailure:                               	2
	V: k8s.io/apimachinery/pkg/apis/meta/v1.StatusSuccess:                               	4
	V: k8s.io/apimachinery/pkg/apis/meta/v1/unstructured.UnstructuredJSONScheme:         	2
	V: k8s.io/apimachinery/pkg/conversion.IgnoreMissingFields:                           	8
	V: k8s.io/apimachinery/pkg/runtime.APIVersionInternal:                               	9
	V: k8s.io/apimachinery/pkg/runtime.ContentTypeJSON:                                  	5
	V: k8s.io/apimachinery/pkg/runtime.InternalGroupVersioner:                           	1
	V: k8s.io/apimachinery/pkg/runtime/serializer/json.DefaultMetaFactory:               	1
	V: k8s.io/apimachinery/pkg/types.StrategicMergePatchType:                            	2
	V: k8s.io/apimachinery/pkg/util/httpstream.HeaderProtocolVersion:                    	2
	V: k8s.io/apimachinery/pkg/util/remotecommand.ExitCodeCauseType:                     	2
	V: k8s.io/apimachinery/pkg/util/remotecommand.NonZeroExitCodeReason:                 	1
	V: k8s.io/apimachinery/pkg/util/remotecommand.StreamProtocolV1Name:                  	3
	V: k8s.io/apimachinery/pkg/util/remotecommand.StreamProtocolV2Name:                  	2
	V: k8s.io/apimachinery/pkg/util/remotecommand.StreamProtocolV3Name:                  	2
	V: k8s.io/apimachinery/pkg/util/remotecommand.StreamProtocolV4Name:                  	2
	V: k8s.io/apimachinery/pkg/util/wait.ErrWaitTimeout:                                 	5
	V: k8s.io/apimachinery/pkg/watch.Added:                                              	8
	V: k8s.io/apimachinery/pkg/watch.Deleted:                                            	6
	V: k8s.io/apimachinery/pkg/watch.DropIfChannelFull:                                  	2
	V: k8s.io/apimachinery/pkg/watch.ErrWatchClosed:                                     	1
	V: k8s.io/apimachinery/pkg/watch.Error:                                              	2
	V: k8s.io/apimachinery/pkg/watch.Modified:                                           	6
	V: k8s.io/apimachinery/pkg/watch.WaitIfChannelFull:                                  	3
======================================================================================================
```