### PR TITLE
Introduce cmd/golist to list provided/imported packages over entire project

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 /generated
 /extract
 /checkapi
+/pkg/util/internal

--- a/Makefile
+++ b/Makefile
@@ -112,8 +112,11 @@ goenv:
 
 build:
 	$(RMLOG)
+	rm -f pkg/util/internal
+	ln -s $$GOROOT/src/cmd/go/internal/ pkg/util/internal
 	$(GO_BUILD) $(GO_BUILD_FLAGS) -o extract $(PROJECT_ROOT)/cmd/extract $(WLOG)
 	$(GO_BUILD) $(GO_BUILD_FLAGS) -o checkapi $(PROJECT_ROOT)/cmd/checkapi $(WLOG)
+	$(GO_BUILD) $(GO_BUILD_FLAGS) -o golist $(PROJECT_ROOT)/cmd/golist $(WLOG)
 
 test:
 	@ $(RMLOG)

--- a/cmd/golist/golist.go
+++ b/cmd/golist/golist.go
@@ -1,0 +1,147 @@
+package main
+
+import (
+	"flag"
+	"fmt"
+	"os"
+	"regexp"
+	"sort"
+	"strings"
+
+	"github.com/gofed/symbols-extractor/pkg/util"
+)
+
+// TODO(jchaloup):
+// - add --version to print a Go version the code was built with
+
+type flags struct {
+	// Go package entry point
+	packagePath *string
+	// List all dependencies
+	allDeps *bool
+	// List provided packages
+	provided *bool
+	// List imported packages
+	imported *bool
+	// List of files to install
+	toinstall  *bool
+	extensions *string
+	// Skip all packages prefixed with packagePath
+	skipSelf *bool
+	// search tests instead
+	tests    *bool
+	showMain *bool
+	//
+	ignoreTrees *string
+	ignoreDirs  *string
+	ignoreRegex *string
+}
+
+func buildFlags() *flags {
+	return &flags{
+		packagePath: flag.String("package-path", "", "Package entry point"),
+		allDeps:     flag.Bool("all-deps", false, "List imported packages including stdlib"),
+		provided:    flag.Bool("provided", false, "List provided packages"),
+		imported:    flag.Bool("imported", false, "List imported packages"),
+		skipSelf:    flag.Bool("skip-self", false, "Skip imported packages with the same --package-path"),
+		tests:       flag.Bool("tests", false, "Apply the listing options over tests"),
+		showMain:    flag.Bool("show-main", false, "Including main files in listings"),
+		ignoreTrees: flag.String("ignore-trees", "", "Directory trees to ignore"),
+		ignoreDirs:  flag.String("ignore-dirs", "", "Directories to ignore"),
+		ignoreRegex: flag.String("ignore-regex", "", "Directories to ignore specified by a regex"),
+		toinstall:   flag.Bool("to-install", false, "List all resources recognized as essential part of the Go project"),
+		extensions:  flag.String("with-extensions", "", "Include all files with the extensions in the recognized resources, e.g. *.proto,*.tmpl"),
+	}
+}
+
+func (f *flags) parse() error {
+	flag.Parse()
+
+	if *f.packagePath == "" {
+		return fmt.Errorf("--package-path is not set")
+	}
+
+	if !*f.provided && !*f.imported && !*f.toinstall {
+		return fmt.Errorf("At least one of --provided, --imported or --to-install must be set")
+	}
+
+	return nil
+}
+
+func main() {
+	f := buildFlags()
+	if err := f.parse(); err != nil {
+		fmt.Fprintf(os.Stderr, "%v\n", err)
+		os.Exit(1)
+	}
+
+	ignore := &util.Ignore{}
+
+	if *f.ignoreTrees != "" {
+		for _, dir := range strings.Split(*f.ignoreTrees, ",") {
+			// skip all ignored dirs that are prefixes of the package-path
+			if strings.HasPrefix(*f.packagePath, dir) {
+				continue
+			}
+			ignore.Trees = append(ignore.Trees, dir)
+		}
+	}
+
+	if *f.ignoreDirs != "" {
+		for _, dir := range strings.Split(*f.ignoreDirs, ",") {
+			// skip all ignored dirs that are prefixes of the package-path
+			if strings.HasPrefix(*f.packagePath, dir) {
+				continue
+			}
+			ignore.Dirs = append(ignore.Dirs, dir)
+		}
+	}
+
+	if *f.ignoreRegex != "" {
+		ignore.Regex = regexp.MustCompile(*f.ignoreRegex)
+	}
+
+	if *f.provided {
+		pkgs, err := util.BuildPackageTree(*f.packagePath, *f.showMain, *f.tests, ignore)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "%v\n", err)
+			os.Exit(1)
+		}
+		sort.Strings(pkgs)
+		for _, item := range pkgs {
+			fmt.Println(item)
+		}
+		return
+	}
+
+	if *f.imported {
+		pkgs, err := util.CollectProjectDeps(*f.packagePath, *f.allDeps, *f.skipSelf, *f.tests, ignore)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "%v\n", err)
+			os.Exit(1)
+		}
+		sort.Strings(pkgs)
+		for _, item := range pkgs {
+			fmt.Println(item)
+		}
+	}
+
+	if *f.toinstall {
+		var exts []string
+		for _, item := range strings.Split(*f.extensions, ",") {
+			if item != "" {
+				exts = append(exts, item)
+			}
+		}
+		pkgs, err := util.CollectInstalledResources(*f.packagePath, exts, ignore)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "%v\n", err)
+			os.Exit(1)
+		}
+		sort.Strings(pkgs)
+		for _, item := range pkgs {
+			fmt.Println(item)
+		}
+	}
+
+}

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -2,13 +2,396 @@ package util
 
 import (
 	"fmt"
+	"go/parser"
+	"go/token"
 	"os"
 	"os/exec"
 	"path"
+	"path/filepath"
+	"regexp"
 	"strings"
 
+	"github.com/gofed/symbols-extractor/pkg/util/internal/load"
+	"github.com/gofed/symbols-extractor/pkg/util/internal/work"
 	"github.com/golang/glog"
 )
+
+func exists(path string) (bool, error) {
+	_, err := os.Stat(path)
+	if err == nil {
+		return true, nil
+	}
+	if os.IsNotExist(err) {
+		return false, nil
+	}
+	return true, err
+}
+
+func findPackageLocation(packagePath string) (string, string, error) {
+	gopath := os.Getenv("GOPATH")
+	if gopath == "" {
+		return "", "", fmt.Errorf("GOPATH not set")
+	}
+
+	var abspath, pathPrefix string
+
+	// first, find the absolute path
+	for _, gpath := range strings.Split(gopath, ":") {
+		abspath = path.Join(gpath, "src", packagePath)
+
+		if e, err := exists(abspath); err == nil && e {
+			pathPrefix = path.Join(gpath, "src")
+			break
+		}
+	}
+
+	if pathPrefix == "" {
+		return "", "", fmt.Errorf("Path %v not found on %v", packagePath, gopath)
+	}
+
+	return abspath, pathPrefix, nil
+}
+
+// Ignore specifies a set of resources to ignore
+type Ignore struct {
+	Dirs  []string
+	Trees []string
+	Regex *regexp.Regexp
+}
+
+func (ignore *Ignore) ignore(path string) bool {
+	if ignore.Regex != nil && ignore.Regex.MatchString(path) {
+		return true
+	}
+
+	for _, dir := range ignore.Trees {
+		if strings.HasPrefix(path+"/", dir+"/") {
+			return true
+		}
+	}
+
+	for _, dir := range ignore.Dirs {
+		if path == dir {
+			return true
+		}
+	}
+	return false
+}
+
+func collectPackageInfos(abspath, pathPrefix string, ignore *Ignore) (map[string]*load.PackagePublic, error) {
+	pkgs := make(map[string]*load.PackagePublic)
+
+	visit := func(path string, info os.FileInfo, err error) error {
+		if !info.IsDir() {
+			return nil
+		}
+
+		relPath := path[len(pathPrefix)+1:]
+		if strings.HasSuffix(relPath, "/") {
+			relPath = relPath[:len(relPath)-1]
+		}
+		// skip .git directory
+		if strings.HasSuffix(relPath, ".git") {
+			return filepath.SkipDir
+		}
+
+		// skip vendor directory
+		if strings.HasSuffix(relPath, "/vendor") {
+			return filepath.SkipDir
+		}
+
+		if ignore.ignore(relPath) {
+			return nil
+		}
+
+		pkgInfo, err := ListPackage(relPath)
+		if err != nil {
+			if strings.Contains(err.Error(), "no Go files in") {
+				return nil
+			}
+			// TODO(jchaloup): remove later
+			if strings.Contains(err.Error(), "build constraints exclude all Go files in") {
+				return nil
+			}
+			panic(err)
+			return nil
+		}
+		if len(pkgInfo.GoFiles) > 0 {
+			pkgs[relPath] = pkgInfo
+		}
+
+		return nil
+	}
+
+	err := filepath.Walk(abspath+"/", visit)
+	if err != nil {
+		return nil, err
+	}
+
+	return pkgs, nil
+}
+
+type OtherResources struct {
+	ProtoFiles []string
+	TmplFiles  []string
+	MDFiles    []string
+	Other      []string
+}
+
+func collectOtherResources(abspath, pathPrefix string, extensions []string, ignore *Ignore) (*OtherResources, error) {
+	otherResources := &OtherResources{}
+
+	visit := func(path string, info os.FileInfo, err error) error {
+		if !info.IsDir() {
+			for _, ext := range extensions {
+				if strings.HasSuffix(path, ext) {
+					switch ext {
+					case ".proto":
+						otherResources.ProtoFiles = append(otherResources.ProtoFiles, path)
+					case ".md":
+						otherResources.MDFiles = append(otherResources.MDFiles, path)
+					default:
+						otherResources.Other = append(otherResources.Other, path)
+					}
+				}
+			}
+			return nil
+		}
+
+		relPath := path[len(pathPrefix)+1:]
+		if strings.HasSuffix(relPath, "/") {
+			relPath = relPath[:len(relPath)-1]
+		}
+		// skip .git directory
+		if strings.HasSuffix(relPath, ".git") {
+			return filepath.SkipDir
+		}
+
+		// skip vendor directory
+		if strings.HasSuffix(relPath, "/vendor") {
+			return filepath.SkipDir
+		}
+
+		if ignore.ignore(relPath) {
+			return nil
+		}
+
+		return nil
+	}
+
+	err := filepath.Walk(abspath+"/", visit)
+	if err != nil {
+		return nil, err
+	}
+
+	return otherResources, nil
+}
+
+func CollectInstalledResources(packagePath string, extensions []string, ignore *Ignore) ([]string, error) {
+	abspath, pathPrefix, err := findPackageLocation(packagePath)
+	if err != nil {
+		return nil, err
+	}
+
+	pkgInfos, err := collectPackageInfos(abspath, pathPrefix, ignore)
+	if err != nil {
+		return nil, err
+	}
+
+	var resources []string
+
+	for _, info := range pkgInfos {
+		resources = append(resources, info.Dir)
+		for _, file := range info.GoFiles {
+			resources = append(resources, path.Join(info.Dir, file))
+		}
+		for _, file := range info.CgoFiles {
+			resources = append(resources, path.Join(info.Dir, file))
+		}
+		for _, file := range info.CFiles {
+			resources = append(resources, path.Join(info.Dir, file))
+		}
+		for _, file := range info.CXXFiles {
+			resources = append(resources, path.Join(info.Dir, file))
+		}
+		for _, file := range info.MFiles {
+			resources = append(resources, path.Join(info.Dir, file))
+		}
+		for _, file := range info.HFiles {
+			resources = append(resources, path.Join(info.Dir, file))
+		}
+		for _, file := range info.FFiles {
+			resources = append(resources, path.Join(info.Dir, file))
+		}
+		for _, file := range info.SFiles {
+			resources = append(resources, path.Join(info.Dir, file))
+		}
+		for _, file := range info.SwigFiles {
+			resources = append(resources, path.Join(info.Dir, file))
+		}
+		for _, file := range info.SwigCXXFiles {
+			resources = append(resources, path.Join(info.Dir, file))
+		}
+		for _, file := range info.SysoFiles {
+			resources = append(resources, path.Join(info.Dir, file))
+		}
+		for _, file := range info.TestGoFiles {
+			resources = append(resources, path.Join(info.Dir, file))
+		}
+		for _, file := range info.XTestGoFiles {
+			resources = append(resources, path.Join(info.Dir, file))
+		}
+
+	}
+
+	otherResources, err := collectOtherResources(abspath, pathPrefix, extensions, ignore)
+	if err != nil {
+		return nil, err
+	}
+
+	if otherResources != nil {
+		if otherResources.ProtoFiles != nil {
+			resources = append(resources, otherResources.ProtoFiles...)
+		}
+		if otherResources.MDFiles != nil {
+			resources = append(resources, otherResources.MDFiles...)
+		}
+		if otherResources.Other != nil {
+			resources = append(resources, otherResources.Other...)
+		}
+	}
+
+	return resources, nil
+}
+
+func CollectProjectDeps(packagePath string, standard bool, skipSelf bool, tests bool, ignore *Ignore) ([]string, error) {
+	abspath, pathPrefix, err := findPackageLocation(packagePath)
+	if err != nil {
+		return nil, err
+	}
+
+	pkgInfos, err := collectPackageInfos(abspath, pathPrefix, ignore)
+	if err != nil {
+		return nil, err
+	}
+
+	imports := make(map[string]struct{})
+
+	if tests {
+		for _, info := range pkgInfos {
+			for _, item := range info.TestImports {
+				if item == "C" {
+					continue
+				}
+				if pos := strings.LastIndex(item, "/vendor/"); pos != -1 {
+					item = item[pos+8:]
+				}
+				if _, ok := imports[item]; !ok {
+					imports[item] = struct{}{}
+				}
+			}
+		}
+	} else {
+		for _, info := range pkgInfos {
+			for _, item := range info.Imports {
+				if item == "C" {
+					continue
+				}
+				if pos := strings.LastIndex(item, "/vendor/"); pos != -1 {
+					item = item[pos+8:]
+				}
+				if _, ok := imports[item]; !ok {
+					imports[item] = struct{}{}
+				}
+			}
+		}
+	}
+
+	var pkgs []string
+
+	for relPath := range imports {
+		if skipSelf && strings.HasPrefix(relPath, packagePath) {
+			continue
+		}
+
+		if ignore.ignore(relPath) {
+			continue
+		}
+
+		pkgInfo, err := ListPackage(relPath)
+		// assuming the stdlib is always processed properly
+		if !standard && err == nil && pkgInfo.Standard {
+			continue
+		}
+
+		pkgs = append(pkgs, relPath)
+	}
+
+	return pkgs, nil
+}
+
+func BuildPackageTree(packagePath string, includeMain bool, tests bool, ignore *Ignore) ([]string, error) {
+	// TODO(jchaloup): strip all main package unless explicitely requested
+	abspath, pathPrefix, err := findPackageLocation(packagePath)
+	if err != nil {
+		return nil, err
+	}
+
+	pkgInfos, err := collectPackageInfos(abspath, pathPrefix, ignore)
+	if err != nil {
+		return nil, err
+	}
+
+	var entryPoints []string
+	if tests {
+		for p, pkgInfo := range pkgInfos {
+			if len(pkgInfo.TestGoFiles) > 0 {
+				entryPoints = append(entryPoints, p)
+			}
+		}
+	} else {
+		for p, pkgInfo := range pkgInfos {
+			// check package name of each file
+			var nonMainFiles []string
+			files := pkgInfo.GoFiles
+			files = append(files, pkgInfo.CgoFiles...)
+			for _, file := range files {
+				f, err := parser.ParseFile(token.NewFileSet(), path.Join(pkgInfo.Dir, file), nil, 0)
+				if err != nil {
+					return nil, err
+				}
+				if !includeMain && f.Name.Name == "main" {
+					continue
+				}
+				nonMainFiles = append(nonMainFiles, file)
+			}
+			if len(nonMainFiles) > 0 {
+				entryPoints = append(entryPoints, p)
+			}
+		}
+	}
+
+	return entryPoints, nil
+}
+
+func ListPackage(path string) (*load.PackagePublic, error) {
+	// TODO(jchaloup): more things need to be init most likely
+	work.BuildModeInit()
+
+	d := load.PackagesAndErrors([]string{path})
+	if d == nil {
+		return nil, fmt.Errorf("No package listing found for %v", path)
+	}
+
+	pkg := d[0]
+	if pkg.Error != nil {
+		return nil, pkg.Error
+	}
+	// Show vendor-expanded paths in listing
+	pkg.TestImports = pkg.Vendored(pkg.TestImports)
+	pkg.XTestImports = pkg.Vendored(pkg.XTestImports)
+	return &pkg.PackagePublic, nil
+}
 
 func ListGoFiles(packagePath string, cgo bool) ([]string, error) {
 


### PR DESCRIPTION
* [x] list go files without invoking `go list` directly
* [x] skip vendor directories
* [x] skip stdlib packages and `C`
* [x] skip all provided packages that has only files with main package
* [x] list provided packages (`./golist --package-path PATH --provided`)
* [x] list imported packages in non-test files (`./golist --package-path PATH --imported`)
* [x] list packages imported by tests (`./golist --package-path PATH --imported --tests`)
* [x] list packages with tests (`./golist --package-path PATH --provided --tests`)